### PR TITLE
Fix page render of \" for DNS Record docs, also reword a bit

### DIFF
--- a/website/docs/r/dns_record_set.markdown
+++ b/website/docs/r/dns_record_set.markdown
@@ -99,7 +99,7 @@ resource "google_dns_managed_zone" "prod" {
 
 ### Adding an SPF record
 
-`\"` must be added around your `rrdatas` for a SPF record. Otherwise `rrdatas` string gets split on spaces.
+Quotes (`""`) must be added around your `rrdatas` for a SPF record. Otherwise `rrdatas` string gets split on spaces.
 
 ```hcl
 resource "google_dns_record_set" "spf" {


### PR DESCRIPTION
Noticed a questionable rendering on  https://www.terraform.io/docs/providers/google/r/dns_record_set.html#adding-an-spf-record