### PR TITLE
Improve provider upgrade docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,29 @@ Requirements
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10+
 -	[Go](https://golang.org/doc/install) 1.11.0 or higher
 
-Building The Provider
+
+Using the provider
+----------------------
+
+See the [Google Provider documentation](https://www.terraform.io/docs/providers/google/index.html) to get started using the
+Google provider.
+
+We recently introduced the `google-beta` provider. See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
+for more details on how to use `google-beta`.
+
+Upgrading the provider
+----------------------
+
+The Google provider doesn't upgrade automatically once you've started using it. After a new release you can run 
+
+```bash
+terraform init -upgrade
+```
+
+to upgrade to the latest stable version of the Google provider. See the [Terraform website](https://www.terraform.io/docs/configuration/providers.html#provider-versions)
+for more information on provider upgrades, and how to set version constraints on your provider.
+
+Building the provider
 ---------------------
 
 Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-google`
@@ -38,17 +60,7 @@ $ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-google
 $ make build
 ```
 
-Using the provider
-----------------------
-
-See the [Google Provider documentation](https://www.terraform.io/docs/providers/google/index.html) to get started using the Google provider.
-
-Upgrading the provider
-----------------------
-
-To upgrade to the latest stable version of the Google provider run `terraform init -upgrade`. See the [Terraform website](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for more information.
-
-Developing the Provider
+Developing the provider
 ---------------------------
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.


### PR DESCRIPTION
Pull provider usage docs above building/development, highlight explicitly that upgrading is manual, call out `google-beta` and link provider-versions here too.

PR is against `2.0.0` but I wouldn't hate getting it into master or making `2.0.0` the primary branch on GitHub until we release 2.0.0.