### PR TITLE
project field is needed on google_comp_firewall.

### DIFF
--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -103,8 +103,7 @@ The following arguments are supported:
 * `allow` -
   (Optional)
   The list of ALLOW rules specified by this firewall. Each rule
-  specifies a 
-  tocol and port-range tuple that describes a permitted
+  specifies a protocol and port-range tuple that describes a permitted
   connection.  Structure is documented below.
 
 * `deny` -


### PR DESCRIPTION
Please update the document about google_compute_firewall.
Change state of the project property from "Optional" to "Required".
I got the following error message if execute "terraform apply" without the project property.
```
Error: Error applying plan:

1 error(s) occurred:

* google_compute_firewall.defualt: 1 error(s) occurred:

* google_compute_firewall.defualt: Invalid value for network: project: required field is not set

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```
Terraform and google provider version.
```
$ terraform version                
Terraform v0.11.10
+ provider.google v1.19.1
```