### PR TITLE
Add service_networking_connection import documentation

### DIFF
--- a/website/docs/r/service_networking_connection.html.markdown
+++ b/website/docs/r/service_networking_connection.html.markdown
@@ -48,3 +48,17 @@ The following arguments are supported:
 * `reserved_peering_ranges` - (Required) Named IP address range(s) of PEERING type reserved for
   this service provider. Note that invoking this method with a different range when connection
   is already established will not reallocate already provisioned service producer subnetworks.
+
+## Import
+
+Service networking connections can be imported using the following accepted format:
+
+```
+$ terraform import google_service_networking_connection.foobar {{network}}:{{service}}
+```
+
+* `network` - Name of VPC network connected with service producers using VPC peering.
+
+* `service` - Provider peering service that is managing peering connectivity for a
+  service provider organization. For Google services that support this functionality it is
+  'servicenetworking.googleapis.com'.


### PR DESCRIPTION
Took me a while to find out how to import an existing service_networking_connection. Had to dive into the source code. Hopefully this docs update helps others.