### PR TITLE
Ensure container node pools' instance_group_urls contains Instance Group URLs

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -501,13 +501,17 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 		}
 		size += int(igm.TargetSize)
 	}
+	instanceGroupUrls, err := getInstanceGroupUrlsFromManagerUrls(config, np.InstanceGroupUrls)
+	if err != nil {
+		return nil, err
+	}
 	nodePool := map[string]interface{}{
 		"name":                np.Name,
 		"name_prefix":         d.Get(prefix + "name_prefix"),
 		"initial_node_count":  np.InitialNodeCount,
 		"node_count":          size / len(np.InstanceGroupUrls),
 		"node_config":         flattenNodeConfig(np.Config),
-		"instance_group_urls": np.InstanceGroupUrls,
+		"instance_group_urls": instanceGroupUrls,
 		"version":             np.Version,
 	}
 


### PR DESCRIPTION
As noted in both resource_container_cluster.go and resource_container_node_pool.go, the instanceGroupUrls returned in a nodePool object are in fact Instance Group Manager URLs.

This pull request ensures that the URLs in the node pool resource/datasource `instance_group_urls` and cluster.node_pool[*].instance_group_urls are the URLs of Instance Groups, not Instance Group managers.

It uses an existing function whose comment explains it all: https://github.com/terraform-providers/terraform-provider-google/blob/5e9a1614e4950eb987c9e3e5bfc81d30116532d2/google/resource_container_cluster.go#L1719-L1737

Fixes #4628