### PR TITLE
Use correct self_link in example for private IP example

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -165,7 +165,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled    = false
-      private_network = google_compute_network.private_network.id
+      private_network = google_compute_network.private_network.self_link
     }
   }
 }


### PR DESCRIPTION
`google_compute_network.private_network.id` isn't a valid network name for private_network, it needs to be a `self_link`. This updates the docs to reflect that.