### PR TITLE
Fix documents GKE cluster_telemetry block Supported values

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -324,7 +324,7 @@ The `default_snat_status` block supports
 *  `disabled` - (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic
 
 The `cluster_telemetry` block supports
-* `type` - Telemetry integration for the cluster. Supported values (`ENABLE, DISABLE, SYSTEM_ONLY`);
+* `type` - Telemetry integration for the cluster. Supported values (`ENABLED, DISABLED, SYSTEM_ONLY`);
    `SYSTEM_ONLY` (Only system components are monitored and logged) is only available in GKE versions 1.15 and later.
 
 The `addons_config` block supports:


### PR DESCRIPTION
expected cluster_telemetry type to be one of [DISABLED ENABLED SYSTEM_ONLY]

https://godoc.org/google.golang.org/api/container/v1beta1#ClusterTelemetry
