### PR TITLE
[Provider documentation] - Fix clone path to align with other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Building the provider
 Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-google`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/hashicorp/; cd $GOPATH/src/github.com/hashicorp/
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
 $ git clone git@github.com:hashicorp/terraform-provider-google
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Building the provider
 Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-google`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
+$ mkdir -p $GOPATH/src/github.com/hashicorp/; cd $GOPATH/src/github.com/hashicorp/
 $ git clone git@github.com:hashicorp/terraform-provider-google
 ```
 


### PR DESCRIPTION
Correct repository initialization command to align with others