### PR TITLE
Cloud Storage: docs improvements for automatic service account

### DIFF
--- a/website/docs/d/storage_project_service_account.html.markdown
+++ b/website/docs/d/storage_project_service_account.html.markdown
@@ -9,15 +9,40 @@ description: |-
 
 # google\_storage\_project\_service\_account
 
-Get the email address of a project's unique Google Cloud Storage service account.
+Get the email address of a project's unique [automatic Google Cloud Storage service account](https://cloud.google.com/storage/docs/projects#service-accounts).
 
-Each Google Cloud project has a unique service account for use with Google Cloud Storage. Only this
-special service account can be used to set up `google_storage_notification` resources.
+For each Google Cloud project, Google maintains a unique service account which
+is used as the identity for various Google Cloud Storage operations, including
+operations involving
+[customer-managed encryption keys](https://cloud.google.com/storage/docs/encryption/customer-managed-keys)
+and those involving
+[storage notifications to pub/sub](https://cloud.google.com/storage/docs/gsutil/commands/notification).
+This automatic Google service account requires access to the relevant Cloud KMS keys or pub/sub topics, respectively, in order for Cloud Storage to use
+these customer-maanged resources.
+
+The service account has a well-known, documented naming format which is parameterised on the numeric Google project ID.
+However, as noted in [the docs](https://cloud.google.com/storage/docs/projects#service-accounts), it is only created when certain relevant actions occur which
+presuppose its existence.
+These actions include calling a [Cloud Storage API endpoint](https://cloud.google.com/storage/docs/json_api/v1/projects/serviceAccount/get) to yield the
+service account's identity, or performing some operations in the UI which must use the service account's identity, such as attempting to list Cloud KMS keys
+on the bucket creation page.
+
+Use of this data source calls the relevant API endpoint to obtain the service account's identity and thus ensures it exists prior to any API operations
+which demand its existence, such as specifying it in Cloud IAM policy.
+Always prefer to use this data source over interpolating the project ID into the well-known format for this service account, as the latter approach may cause
+Terraform apply errors in cases where the service account does not yet exist.
+
+>  When you write Terraform code which uses features depending on this service account *and* your Terraform code adds the service account in IAM policy on other resources,
+   you must take care for race conditions between the establishment of the IAM policy and creation of the relevant Cloud Storage resource.
+   Cloud Storage APIs will require permissions on resources such as pub/sub topics or Cloud KMS keys to exist *before* the attempt to utilise them in a
+   bucket configuration, otherwise the API calls will fail.
+   You may need to use `depends_on` to create an explicit dependency between the IAM policy resource and the Cloud Storage resource which depends on it.
+   See the examples here and in the [`google_storage_notification`](/docs/providers/google/r/storage_notification.html) resource.
 
 For more information see
 [the API reference](https://cloud.google.com/storage/docs/json_api/v1/projects/serviceAccount).
 
-## Example Usage
+## Example Usage – pub/sub notifications
 
 ```hcl
 data "google_storage_project_service_account" "gcs_account" {
@@ -28,6 +53,32 @@ resource "google_pubsub_topic_iam_binding" "binding" {
   role  = "roles/pubsub.publisher"
 
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+```
+
+## Example Usage – Cloud KMS keys
+
+```hcl
+data "google_storage_project_service_account" "gcs_account" {
+}
+
+resource "google_crypto_key_iam_binding" "binding" {
+  crypto_key_id = "your-crypto-key-id"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+
+resource "google_storage_bucket" "bucket" {
+  name = "kms-protected-bucket"
+
+  encryption {
+    default_kms_key_name = "your-crypto-key-id"
+  }
+
+  # Ensure the KMS crypto-key IAM binding for the service account exists prior to the
+  # bucket attempting to utilise the crypto-key.
+  depends_on = [google_crypto_key_iam_binding.binding]
 }
 ```
 

--- a/website/docs/d/storage_project_service_account.html.markdown
+++ b/website/docs/d/storage_project_service_account.html.markdown
@@ -18,7 +18,7 @@ operations involving
 and those involving
 [storage notifications to pub/sub](https://cloud.google.com/storage/docs/gsutil/commands/notification).
 This automatic Google service account requires access to the relevant Cloud KMS keys or pub/sub topics, respectively, in order for Cloud Storage to use
-these customer-maanged resources.
+these customer-managed resources.
 
 The service account has a well-known, documented naming format which is parameterised on the numeric Google project ID.
 However, as noted in [the docs](https://cloud.google.com/storage/docs/projects#service-accounts), it is only created when certain relevant actions occur which

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -164,9 +164,20 @@ The `logging` block supports:
 
 The `encryption` block supports:
 
-* `default_kms_key_name`: A Cloud KMS key that will be used to encrypt objects inserted into this bucket, if no encryption method is specified.
+* `default_kms_key_name`: The `id` of a Cloud KMS key that will be used to encrypt objects inserted into this bucket, if no encryption method is specified.
   You must pay attention to whether the crypto key is available in the location that this bucket is created in.
   See [the docs](https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys) for more details.
+
+-> As per [the docs](https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys) for customer-managed encryption keys, the IAM policy for the
+  specified key must permit the [automatic Google Cloud Storage service account](https://cloud.google.com/storage/docs/projects#service-accounts) for the bucket's
+  project to use the specified key for encryption and decryption operations.
+  Although the service account email address follows a well-known format, the service account is created on-demand and may not necessarily exist for your project
+  until a relevant action has occurred which triggers its creation.
+  You should use the [`google_storage_project_service_account`](/docs/providers/google/d/storage_project_service_account.html) data source to obtain the email
+  address for the service account when configuring IAM policy on the Cloud KMS key.
+  This data source calls an API which creates the account if required, ensuring your Terraform applies cleanly and repeatedly irrespective of the
+  state of the project.
+  You should take care for race conditions when the same Terraform manages IAM policy on the Cloud KMS crypto key. See the data source page for more details.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_notification.html.markdown
+++ b/website/docs/r/storage_notification.html.markdown
@@ -10,16 +10,18 @@ description: |-
 # google\_storage\_notification
 
 Creates a new notification configuration on a specified bucket, establishing a flow of event notifications from GCS to a Cloud Pub/Sub topic.
- For more information see 
-[the official documentation](https://cloud.google.com/storage/docs/pubsub-notifications) 
-and 
+ For more information see
+[the official documentation](https://cloud.google.com/storage/docs/pubsub-notifications)
+and
 [API](https://cloud.google.com/storage/docs/json_api/v1/notifications).
 
 In order to enable notifications, a special Google Cloud Storage service account unique to the project
-must have the IAM permission "projects.topics.publish" for a Cloud Pub/Sub topic in the project. To get the service
-account's email address, use the `google_storage_project_service_account` datasource's `email_address` value, and see below
-for an example of enabling notifications by granting the correct IAM permission. See
-[the notifications documentation](https://cloud.google.com/storage/docs/gsutil/commands/notification) for more details.
+must exist and have the IAM permission "projects.topics.publish" for a Cloud Pub/Sub topic in the project.
+This service account is not created automatically when a project is created.
+To ensure the service account exists and obtain its email address for use in granting the correct IAM permission, use the
+[`google_storage_project_service_account`](/docs/providers/google/d/storage_project_service_account.html)
+datasource's `email_address` value, and see below for an example of enabling notifications by granting the correct IAM permission.
+See [the notifications documentation](https://cloud.google.com/storage/docs/gsutil/commands/notification) for more details.
 
 >**NOTE**: This resource can affect your storage IAM policy. If you are using this in the same config as your storage IAM policy resources, consider
 making this resource dependent on those IAM resources via `depends_on`. This will safeguard against errors due to IAM race conditions.
@@ -68,11 +70,11 @@ The following arguments are supported:
 
 * `payload_format` - (Required) The desired content of the Payload. One of `"JSON_API_V1"` or `"NONE"`.
 
-* `topic` - (Required) The Cloud PubSub topic to which this subscription publishes. Expects either the 
-    topic name, assumed to belong to the default GCP provider project, or the project-level name, 
+* `topic` - (Required) The Cloud PubSub topic to which this subscription publishes. Expects either the
+    topic name, assumed to belong to the default GCP provider project, or the project-level name,
     i.e. `projects/my-gcp-project/topics/my-topic` or `my-topic`. If the project is not set in the provider,
     you will need to use the project-level name.
-    
+
 - - -
 
 * `custom_attributes` - (Optional)  A set of key/value attribute pairs to attach to each Cloud PubSub message published for this notification subscription


### PR DESCRIPTION
I've improved the documentation with warnings, cross-references and
additional examples around appropriate use of the
google_storage_project_service_account resource to ensure the proper
existence of the Cloud Storage automatic internal service account prior
to utilising any features which depend on the same.

There are various subtleties around the lifecycle of this service
account which may be non-obvious when using these features.  Moreover,
the service account is always implicitly created as a side-effect of
operations expected to be read-only (clicking in the UI or making a GET
call to an API are sufficient). It is possible to write Terraform code
which assumes the existence of the service account through interpolating
the project ID into the well-known email address format and the same
Terraform will work in some or many cases when the service account
already exists. Such Terraform contains latent failure conditions and
cannot apply cleanly to new projects.

We must be defensive in these cases and ensure users are aware of the
relevant data source and the importance of its use.

The documentation was already good for the creation of
google_storage_notification objects and the associated permissions
required on pub/sub topics. I've added warnings relating to the use of
the data source when specifying Cloud KMS keys on storage buckets, which
did not have any hooks on the storage_bucket resource's documentation to
these subtleties.