### PR TITLE
Update cloudfunctions_function.html.markdown

### DIFF
--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -131,7 +131,7 @@ Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`, `"go113"`.
 
 * `environment_variables` - (Optional) A set of key/value environment variable pairs to assign to the function.
 
-* `vpc_connector` - (Optional) The VPC Network Connector that this cloud function can connect to. It can be either the fully-qualified URI, or the short name of the network connector resource. The format of this field is `projects/*/locations/*/connectors/*`.
+* `vpc_connector` - (Optional) The VPC Network Connector that this cloud function can connect to. It should be set up as fully-qualified URI. The format of this field is `projects/*/locations/*/connectors/*`.
 
 * `vpc_connector_egress_settings` - (Optional) The egress settings for the connector, controlling what traffic is diverted through it. Allowed values are `ALL_TRAFFIC` and `PRIVATE_RANGES_ONLY`. Defaults to `PRIVATE_RANGES_ONLY`. If unset, this field preserves the previously set value.
 


### PR DESCRIPTION
For `vpc_connector`, you cannot use just the name of the connector, only the fully-qualified URI works. That's also stated in [GCP documentation](https://cloud.google.com/functions/docs/networking/connecting-vpc) when you deploy a function. When you use just the name of the `vpc_connector`, error thrown is `VPC connector is not ready yet or does not exist`