### PR TITLE
Switch http://www.gstatic.com/ipranges/goog.json to use https

### DIFF
--- a/google/data_source_google_netblock_ip_ranges.go
+++ b/google/data_source_google_netblock_ip_ranges.go
@@ -70,7 +70,7 @@ func dataSourceGoogleNetblockIpRangesRead(d *schema.ResourceData, meta interface
 		d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"])
 	case "google-netblocks":
 		// https://cloud.google.com/vpc/docs/configure-private-google-access?hl=en#ip-addr-defaults
-		const GOOGLE_NETBLOCK_URL = "http://www.gstatic.com/ipranges/goog.json"
+		const GOOGLE_NETBLOCK_URL = "https://www.gstatic.com/ipranges/goog.json"
 		CidrBlocks, err := getCidrBlocksFromUrl(GOOGLE_NETBLOCK_URL)
 
 		if err != nil {


### PR DESCRIPTION
It seems that the HTTP endpoint does not work anymore and also it is always good practice to fetch this data from HTTPS.

Fixes #7155