### PR TITLE
Added option 'all' for compute_firewall protocols as per #750

### DIFF
--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -217,7 +217,7 @@ The `allow` block supports:
   The IP protocol to which this rule applies. The protocol type is
   required when creating a firewall rule. This value can either be
   one of the following well known protocol strings (tcp, udp,
-  icmp, esp, ah, sctp, ipip), or the IP protocol number.
+  icmp, esp, ah, sctp, ipip, all), or the IP protocol number.
 
 * `ports` -
   (Optional)


### PR DESCRIPTION
Fixes #750

Changes proposed in this pull request:

* Added 'all' protocol option for compute_firewall resource