### PR TITLE
`point_in_time_recovery_enabled` for PostgreSQL

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -282,7 +282,7 @@ The optional `settings.backup_configuration` subblock supports:
 
 * `start_time` - (Optional) `HH:MM` format time indicating when backup
     configuration starts.
-* `point_in_time_recovery_enabled` - (Optional) True if Point-in-time recovery is enabled. Will restart database if enabled after instance creation. 
+* `point_in_time_recovery_enabled` - (Optional) True if Point-in-time recovery is enabled. Will restart database if enabled after instance creation. This argument is only valid for PostgreSQL instances
 
 The optional `settings.ip_configuration` subblock supports:
 


### PR DESCRIPTION
This is only valid for PostgreSQL instances as shown by the error below:

```
google_sql_database_instance.primary: Creating...

Error: Error, failed to create instance store-8fc15b58: googleapi: Error 400: Invalid request: Point-in-time recovery can only be enabled for Postgres instances
```