### PR TITLE
Refer to the value of `labels` as a 'map'

### DIFF
--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 * `retention_policy` - (Optional) Configuration of the bucket's data retention policy for how long objects in the bucket should be retained. Structure is documented below.
 
-* `labels` - (Optional) A set of key/value label pairs to assign to the bucket.
+* `labels` - (Optional) A map of key/value label pairs to assign to the bucket.
 
 * `logging` - (Optional) The bucket's [Access & Storage Logs](https://cloud.google.com/storage/docs/access-logs) configuration.
 


### PR DESCRIPTION
Labels is described as a 'set of key/value label pairs'. This is correct from an English grammar perspective, however in our case a Terraform 'set' is a strictly defined collection type, described here https://www.terraform.io/docs/configuration/types.html#set-

To avoid misleading users, can we refer to it as a 'map' instead, as this is the actual Terraform collection type we want?

Thanks,
Jak