### PR TITLE
[google_container_node_pool] Fix autoscaling.max_node_count validation rule

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -83,7 +83,7 @@ var schemaNodePool = map[string]*schema.Schema{
 				"max_node_count": {
 					Type:         schema.TypeInt,
 					Required:     true,
-					ValidateFunc: validation.IntAtLeast(1),
+					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `Maximum number of nodes in the NodePool. Must be >= min_node_count.`,
 				},
 			},
@@ -551,6 +551,9 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 
 	if v, ok := d.GetOk(prefix + "autoscaling"); ok {
 		autoscaling := v.([]interface{})[0].(map[string]interface{})
+		if autoscaling["max_node_count"].(int) < autoscaling["min_node_count"].(int) {
+			return nil, fmt.Errorf("autoscaling.max_node_count must be >= autoscaling.min_node_count on node pool %s", name)
+		}
 		np.Autoscaling = &containerBeta.NodePoolAutoscaling{
 			Enabled:         true,
 			MinNodeCount:    int64(autoscaling["min_node_count"].(int)),

--- a/google/resource_container_node_pool_test.go
+++ b/google/resource_container_node_pool_test.go
@@ -396,6 +396,18 @@ func TestAccContainerNodePool_regionalAutoscaling(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccContainerNodePool_updateAutoscalingZero(cluster, np),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "0"),
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "0"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccContainerNodePool_basic(cluster, np),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count"),
@@ -442,6 +454,18 @@ func TestAccContainerNodePool_autoscaling(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "0"),
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "5"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerNodePool_updateAutoscalingZero(cluster, np),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "0"),
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "0"),
 				),
 			},
 			{
@@ -950,6 +974,25 @@ resource "google_container_node_pool" "np" {
   autoscaling {
     min_node_count = 0
     max_node_count = 5
+  }
+}
+`, cluster, np)
+}
+
+func testAccContainerNodePool_updateAutoscalingZero(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 0
   }
 }
 `, cluster, np)


### PR DESCRIPTION
The current validation rule for `autoscaling.max_node_count` checks that the value is >= 1, although the description of this field states that the value must be >= `autoscaling.min_node_count`:

https://github.com/hashicorp/terraform-provider-google/blob/23a4a7398a8d153781911d0b4f0e125814448c2f/google/resource_container_node_pool.go#L86-L87

I'm therefore not able to scale down to 0 nodes my pool, using 0 for both min and max.

As validation rules are not context-aware, I've added one further in the code.