### PR TITLE
Add NotificationConfig to google_container_cluster

### DIFF
--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -2480,12 +2480,22 @@ func expandNotificationConfig(configured interface{}) *containerBeta.Notificatio
 	}
 
 	notificationConfig := l[0].(map[string]interface{})
-	pubsub := notificationConfig["pubsub"].(map[string]interface{})
+	if v, ok := notificationConfig["pubsub"]; ok {
+		if len(v.([]interface{})) > 0 {
+			pubsub := notificationConfig["pubsub"].([]interface{})[0].(map[string]interface{})
+
+			return &containerBeta.NotificationConfig{
+				Pubsub: &containerBeta.PubSub{
+					Enabled: pubsub["enabled"].(bool),
+					Topic:   pubsub["topic"].(string),
+				},
+			}
+		}
+	}
 
 	return &containerBeta.NotificationConfig{
 		Pubsub: &containerBeta.PubSub{
-			Enabled: pubsub["enabled"].(bool),
-			Topic:   pubsub["topic"].(string),
+			Enabled: false,
 		},
 	}
 }

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -1947,8 +1947,8 @@ resource "google_container_cluster" "notification_config" {
 
   notification_config {
 	pubsub {
-	  enabled = true,
-	  topic = %s  
+	  enabled = true
+	  topic = "%s"  
 	}
   }
 }
@@ -1964,8 +1964,8 @@ resource "google_container_cluster" "notification_config" {
 
   notification_config {
 	pubsub {
-	  enabled = true,
-	  topic = %s  
+	  enabled = true
+	  topic = "%s"  
 	}
   }
 }
@@ -1981,7 +1981,7 @@ resource "google_container_cluster" "notification_config" {
 
   notification_config {
 	pubsub {
-	  enabled = false,
+	  enabled = false
 	}
   }
 }


### PR DESCRIPTION
This PR aims to introduce a new attribute called `notification_config` on `google_container_cluster` which enables a feature to send pubsub notifications on cluster upgrades. It's currently in beta. As this is my first contributing to a provider, I'm a bit unsure how to test it past writing tests. 

References:
* https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-upgrade-notifications?hl=el
* https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.NotificationConfig


Closes #7337 