### PR TITLE
Add service_networking_connection import documentation

### DIFF
--- a/website/docs/r/service_networking_connection.html.markdown
+++ b/website/docs/r/service_networking_connection.html.markdown
@@ -49,3 +49,11 @@ The following arguments are supported:
 * `reserved_peering_ranges` - (Required) Named IP address range(s) of PEERING type reserved for
   this service provider. Note that invoking this method with a different range when connection
   is already established will not reallocate already provisioned service producer subnetworks.
+
+  ## Import
+
+  Service networking connections can be imported using the following accepted format:
+
+  ```
+  $ terraform import google_service_networking_connection.foobar {{network}}:{{service}}
+  ```


### PR DESCRIPTION
This adds an example import command to the `service_networking_connection` resource.

It is a copy of #4307 + [feedback](https://github.com/hashicorp/terraform-provider-google/pull/4307#pullrequestreview-338323416), which appears to have gone stale.