### PR TITLE
adds google_cloud_run_service data source

### DIFF
--- a/google/data_source_cloud_run_service.go
+++ b/google/data_source_cloud_run_service.go
@@ -10,6 +10,7 @@ func dataSourceGoogleCloudRunService() *schema.Resource {
 
 	dsSchema := datasourceSchemaFromResourceSchema(resourceCloudRunService().Schema)
 	addRequiredFieldsToSchema(dsSchema, "name", "location")
+	addOptionalFieldsToSchema(dsSchema, "project")
 
 	return &schema.Resource{
 		Read:   dataSourceGoogleCloudRunServiceRead,

--- a/google/data_source_cloud_run_service.go
+++ b/google/data_source_cloud_run_service.go
@@ -1,0 +1,29 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleCloudRunService() *schema.Resource {
+
+	dsSchema := datasourceSchemaFromResourceSchema(resourceCloudRunService().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name", "location")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleCloudRunServiceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleCloudRunServiceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	id, err := replaceVars(d, config, "locations/{{location}}/namespaces/{{project}}/services/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceCloudRunServiceRead(d, meta)
+}

--- a/google/data_source_cloud_run_service_test.go
+++ b/google/data_source_cloud_run_service_test.go
@@ -28,7 +28,57 @@ func TestAccDataSourceGoogleCloudRunService_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceGoogleCloudRunService_optionalProject(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudRunServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCloudRunService_optionalProject(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_cloud_run_service.foo", "google_cloud_run_service.foo"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceGoogleCloudRunService_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_cloud_run_service" "foo" {
+  name     = "tf-test-cloudrun-srv%{random_suffix}"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+data "google_cloud_run_service" "foo" {
+  name     = google_cloud_run_service.foo.name
+  location = google_cloud_run_service.foo.location
+  project  = google_cloud_run_service.foo.project
+}
+`, context)
+}
+
+func testAccDataSourceGoogleCloudRunService_optionalProject(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_cloud_run_service" "foo" {
   name     = "tf-test-cloudrun-srv%{random_suffix}"

--- a/google/data_source_cloud_run_service_test.go
+++ b/google/data_source_cloud_run_service_test.go
@@ -1,0 +1,56 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGoogleCloudRunService_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudRunServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCloudRunService_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_cloud_run_service.foo", "google_cloud_run_service.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleCloudRunService_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_cloud_run_service" "foo" {
+  name     = "tf-test-cloudrun-srv%{random_suffix}"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+data "google_cloud_run_service" "foo" {
+  name     = google_cloud_run_service.foo.name
+  location = google_cloud_run_service.foo.location
+}
+`, context)
+}

--- a/google/provider.go
+++ b/google/provider.go
@@ -564,6 +564,7 @@ func Provider() *schema.Provider {
 			"google_client_config":                                dataSourceGoogleClientConfig(),
 			"google_client_openid_userinfo":                       dataSourceGoogleClientOpenIDUserinfo(),
 			"google_cloudfunctions_function":                      dataSourceGoogleCloudFunctionsFunction(),
+			"google_cloud_run_service":                            dataSourceGoogleCloudRunService(),
 			"google_composer_image_versions":                      dataSourceGoogleComposerImageVersions(),
 			"google_compute_address":                              dataSourceGoogleComputeAddress(),
 			"google_compute_backend_service":                      dataSourceGoogleComputeBackendService(),

--- a/website/docs/d/cloud_run_service.html.markdown
+++ b/website/docs/d/cloud_run_service.html.markdown
@@ -26,17 +26,14 @@ data "google_cloud_run_service" "run-service" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of a Cloud Function.
-* `location` - (Required) The name of a Cloud Function.
+* `name` - (Required) The name of a Cloud Run.
+* `location` - (Required) The name of a Cloud Run.
 
 - - -
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `region` - (Optional) The region in which the resource belongs. If it
-    is not provided, the provider region is used.
-
 ## Attributes Reference
 
-TBD
+See [google_cloud_run_service](https://www.terraform.io/docs/providers/google/r/cloud_run_service.html#argument-reference) resource for details of the available attributes.

--- a/website/docs/d/cloud_run_service.html.markdown
+++ b/website/docs/d/cloud_run_service.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Cloud Run"
+layout: "google"
+page_title: "Google: google_cloud_run_service"
+sidebar_current: "docs-google-cloud-run-service"
+description: |-
+  Get information about a Google Cloud Run Service.
+---
+
+# google\_cloud\_run\_service
+
+Get information about a Google Cloud Run. For more information see
+the [official documentation](https://cloud.google.com/run/docs/)
+and [API](https://cloud.google.com/run/docs/apis).
+
+## Example Usage
+
+```hcl
+data "google_cloud_run_service" "run-service" {
+  name = "my-service"
+  location = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of a Cloud Function.
+* `location` - (Required) The name of a Cloud Function.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The region in which the resource belongs. If it
+    is not provided, the provider region is used.
+
+## Attributes Reference
+
+TBD

--- a/website/google.erb
+++ b/website/google.erb
@@ -901,6 +901,16 @@
     <a href="#">Cloud Run</a>
     <ul class="nav">
       <li>
+        <a href="#">Data Sources</a>
+        <ul class="nav nav-auto-expand">
+    
+          <li>
+          <a href="/docs/providers/google/d/cloud_run_service.html">google_cloud_run_service</a>
+          </li>
+    
+        </ul>
+      </li>
+      <li>
         <a href="#">Resources</a>
         <ul class="nav nav-auto-expand">
   


### PR DESCRIPTION
Creates a data source for cloud run service as mentioned in #7363 

Would be good to get the early feedback.

When it comes to documentation for time being, I left `TBD` and still some references to `Cloud Function` as I used that for the template. For documentation object reference to do you copy text from resources or do you just link, what is the preferred way?

Closes: #7363

```release-note:enhancement
cloudrun: Add support for a `google_cloud_run_service` datasource
```
