### PR TITLE
Include devstorage.read_only scope in example

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -61,6 +61,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     }
 
     oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
@@ -87,6 +88,7 @@ resource "google_container_cluster" "primary" {
 
   node_config {
     oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]


### PR DESCRIPTION
OAuth scope `https://www.googleapis.com/auth/devstorage.read_only` is required for nodes to be able to pull images from GCR

Unfortunately, it is not included by default when `oauth_scopes` aren't specified

I was struggling with "Why my pod goes to ImagePullBackoff", before actually reading through the docs.

I think it would be much more obvious if example in docs incuded that scope