### PR TITLE
Note that recurring_window should use UTC time

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -470,6 +470,7 @@ recurring maintenance operations.
 Specify `start_time` and `end_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) date format.  The start time's date is
 the initial date that the window starts, and the end time is used for calculating duration.  Specify `recurrence` in
 [RFC5545](https://tools.ietf.org/html/rfc5545#section-3.8.5.3) RRULE format, to specify when this recurs.
+UTC time should be used, since GKE returns this format, and will otherwise cause a permanent diff.
 
 Examples:
 ```
@@ -485,8 +486,8 @@ maintenance_policy {
 ```
 maintenance_policy {
   recurring_window {
-    start_time = "2019-01-01T09:00:00-04:00"
-    end_time = "2019-01-01T17:00:00-04:00"
+    start_time = "2019-01-01T09:00:00Z"
+    end_time = "2019-01-01T17:00:00Z"
     recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
   }
 }

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -467,10 +467,10 @@ maintenance_policy {
 * `recurring_window` - (Optional) Time window for
 recurring maintenance operations.
 
-Specify `start_time` and `end_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) date format.  The start time's date is
+Specify `start_time` and `end_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) "Zulu" date format.  The start time's date is
 the initial date that the window starts, and the end time is used for calculating duration.  Specify `recurrence` in
 [RFC5545](https://tools.ietf.org/html/rfc5545#section-3.8.5.3) RRULE format, to specify when this recurs.
-UTC time should be used, since GKE returns this format, and will otherwise cause a permanent diff.
+Note that GKE may accept other formats, but will return values in UTC, causing a permanent diff.
 
 Examples:
 ```


### PR DESCRIPTION
Fixes permadiff from GKE always returning UTC.
Alternatively, we could do a "real" timezone aware comparison, which might be a better solution?

```release-note:none
```
