### PR TITLE
GKE documentation recommends default oauth scope

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -61,8 +61,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     }
 
     oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/cloud-platform"
     ]
   }
 }
@@ -87,8 +86,7 @@ resource "google_container_cluster" "primary" {
 
   node_config {
     oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/cloud-platform"
     ]
 
     metadata = {
@@ -440,7 +438,7 @@ Minimum CPU platform to be used for NAP created node pools. The instance may be 
 specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such
 as "Intel Haswell" or "Intel Sandy Bridge".
 
-* `oauth_scopes` - (Optional) Scopes that are used by NAP when creating node pools.
+* `oauth_scopes` - (Optional) Scopes that are used by NAP when creating node pools. Use the "https://www.googleapis.com/auth/cloud-platform" scope to grant access to all APIs. It is recommended that you set `service_account` to a non-default service account and grant IAM roles to that service account for only the resources that it needs. 
 
 -> `monitoring.write` is always enabled regardless of user input.  `monitoring` and `logging.write` may also be enabled depending on the values for `monitoring_service` and `logging_service`.
 


### PR DESCRIPTION
The `oauth_scopes` section of `google_container_cluster` has generated a lot of confusion since GCP [no longer uses access scopes](https://cloud.google.com/kubernetes-engine/docs/how-to/access-scopes). The [best practice](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#best_practices) is to use the `https://www.googleapis.com/auth/cloud-platform` scope and constrain permissions at the service account level. As currently documented, the examples guide the developer down the path of using legacy access scopes. This PR updates the documentation with the recommended configuration. 

Related: https://github.com/hashicorp/terraform-provider-google/issues/1962, https://github.com/hashicorp/terraform-provider-google/issues/1817, https://github.com/hashicorp/terraform-provider-google/pull/7391