### PR TITLE
Add support for Monthly/Yearly BigQuery Partitioning

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -451,13 +451,13 @@ func resourceBigQueryTable() *schema.Resource {
 							Description: `Number of milliseconds for which to keep the storage for a partition.`,
 						},
 
-						// Type: [Required] The supported types are DAY and HOUR, which will generate
-						// one partition per day or hour based on data loading time.
+						// Type: [Required] The supported types are DAY, HOUR, MONTH, and YEAR, which will generate
+						// one partition per day, hour, month, and year, respectively.
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  `The supported types are DAY and HOUR, which will generate one partition per day or hour based on data loading time.`,
-							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR"}, false),
+							Description:  `The supported types are DAY, HOUR, MONTH, and YEAR, which will generate one partition per day, hour, month, and year, respectively.`,
+							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR", "MONTHLY", "YEAR"}, false),
 						},
 
 						// Field: [Optional] The field used to determine how to create a time-based

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -457,7 +457,7 @@ func resourceBigQueryTable() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  `The supported types are DAY, HOUR, MONTH, and YEAR, which will generate one partition per day, hour, month, and year, respectively.`,
-							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR", "MONTHLY", "YEAR"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR", "MONTH", "YEAR"}, false),
 						},
 
 						// Field: [Optional] The field used to determine how to create a time-based

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -28,7 +28,7 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBigQueryTableUpdated(datasetID, tableID, "DAY"),
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -84,7 +84,7 @@ func TestAccBigQueryTable_HourlyTimePartitioning(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBigQueryTableUpdated(datasetID, tableID, "HOUR"),
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -115,7 +115,7 @@ func TestAccBigQueryTable_MonthlyTimePartitioning(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBigQueryTableUpdated(datasetID, tableID, "MONTH"),
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -146,7 +146,7 @@ func TestAccBigQueryTable_YearlyTimePartitioning(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBigQueryTableUpdated(datasetID, tableID, "YEAR"),
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -1067,7 +1067,7 @@ resource "google_bigquery_table" "mv_test" {
 `, datasetID, tableID, mViewID, enable_refresh, refresh_interval, query)
 }
 
-func testAccBigQueryTableUpdated(datasetID, tableID, partitioningType string) string {
+func testAccBigQueryTableUpdated(datasetID, tableID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
 	dataset_id = "%s"
@@ -1078,7 +1078,7 @@ resource "google_bigquery_table" "test" {
 	dataset_id = google_bigquery_dataset.test.dataset_id
 
 	time_partitioning {
-		type = "%s"
+		type = "DAY"
 	}
 
 	schema = <<EOH
@@ -1125,7 +1125,7 @@ resource "google_bigquery_table" "test" {
 EOH
 
 }
-`, datasetID, tableID, partitioningType)
+`, datasetID, tableID)
 }
 
 func testAccBigQueryTableFromGCS(datasetID, tableID, bucketName, objectName, content, format, quoteChar string) string {

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -20,7 +20,7 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableDailyTimePartitioning(datasetID, tableID),
+				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "DAY"),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -76,7 +76,7 @@ func TestAccBigQueryTable_HourlyTimePartitioning(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableHourlyTimePartitioning(datasetID, tableID),
+				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "HOUR"),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -107,7 +107,7 @@ func TestAccBigQueryTable_MonthlyTimePartitioning(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableMonthlyTimePartitioning(datasetID, tableID),
+				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "MONTH"),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -138,7 +138,7 @@ func TestAccBigQueryTable_YearlyTimePartitioning(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableYearlyTimePartitioning(datasetID, tableID),
+				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "YEAR"),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -462,7 +462,7 @@ func testAccCheckBigQueryTableDestroyProducer(t *testing.T) func(s *terraform.St
 	}
 }
 
-func testAccBigQueryTableDailyTimePartitioning(datasetID, tableID string) string {
+func testAccBigQueryTableTimePartitioning(datasetID, tableID, partitioningType string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
 	dataset_id = "%s"
@@ -473,7 +473,7 @@ resource "google_bigquery_table" "test" {
 	dataset_id = google_bigquery_dataset.test.dataset_id
 
 	time_partitioning {
-		type                     = "DAY"
+		type                     = "%s"
 		field                    = "ts"
 		require_partition_filter = true
 	}
@@ -516,178 +516,7 @@ resource "google_bigquery_table" "test" {
 EOH
 
 }
-`, datasetID, tableID)
-}
-
-func testAccBigQueryTableHourlyTimePartitioning(datasetID, tableID string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-	dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-	table_id   = "%s"
-	dataset_id = google_bigquery_dataset.test.dataset_id
-
-	time_partitioning {
-		type                     = "HOUR"
-		field                    = "ts"
-		require_partition_filter = true
-	}
-	clustering = ["some_int", "some_string"]
-	schema     = <<EOH
-[
-	{
-		"name": "ts",
-		"type": "TIMESTAMP"
-	},
-	{
-		"name": "some_string",
-		"type": "STRING"
-	},
-	{
-		"name": "some_int",
-		"type": "INTEGER"
-	},
-	{
-		"name": "city",
-		"type": "RECORD",
-		"fields": [
-	{
-		"name": "id",
-		"type": "INTEGER"
-	},
-	{
-		"name": "coord",
-		"type": "RECORD",
-		"fields": [
-		{
-		"name": "lon",
-		"type": "FLOAT"
-		}
-		]
-	}
-		]
-	}
-]
-EOH
-
-}
-`, datasetID, tableID)
-}
-
-func testAccBigQueryTableMonthlyTimePartitioning(datasetID, tableID string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-	dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-	table_id   = "%s"
-	dataset_id = google_bigquery_dataset.test.dataset_id
-
-	time_partitioning {
-		type                     = "MONTH"
-		field                    = "ts"
-		require_partition_filter = true
-	}
-	clustering = ["some_int", "some_string"]
-	schema     = <<EOH
-[
-	{
-		"name": "ts",
-		"type": "TIMESTAMP"
-	},
-	{
-		"name": "some_string",
-		"type": "STRING"
-	},
-	{
-		"name": "some_int",
-		"type": "INTEGER"
-	},
-	{
-		"name": "city",
-		"type": "RECORD",
-		"fields": [
-	{
-		"name": "id",
-		"type": "INTEGER"
-	},
-	{
-		"name": "coord",
-		"type": "RECORD",
-		"fields": [
-		{
-		"name": "lon",
-		"type": "FLOAT"
-		}
-		]
-	}
-		]
-	}
-]
-EOH
-
-}
-`, datasetID, tableID)
-}
-
-func testAccBigQueryTableYearlyTimePartitioning(datasetID, tableID string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-	dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-	table_id   = "%s"
-	dataset_id = google_bigquery_dataset.test.dataset_id
-
-	time_partitioning {
-		type                     = "YEAR"
-		field                    = "ts"
-		require_partition_filter = true
-	}
-	clustering = ["some_int", "some_string"]
-	schema     = <<EOH
-[
-	{
-		"name": "ts",
-		"type": "TIMESTAMP"
-	},
-	{
-		"name": "some_string",
-		"type": "STRING"
-	},
-	{
-		"name": "some_int",
-		"type": "INTEGER"
-	},
-	{
-		"name": "city",
-		"type": "RECORD",
-		"fields": [
-	{
-		"name": "id",
-		"type": "INTEGER"
-	},
-	{
-		"name": "coord",
-		"type": "RECORD",
-		"fields": [
-		{
-		"name": "lon",
-		"type": "FLOAT"
-		}
-		]
-	}
-		]
-	}
-]
-EOH
-
-}
-`, datasetID, tableID)
+`, datasetID, tableID, partitioningType)
 }
 
 func testAccBigQueryTableKms(cryptoKeyName, datasetID, tableID string) string {


### PR DESCRIPTION
Closes #7450

This PR is based on #6675 from earlier this year that added Hourly partitioning

- Relax validation for 2 new values
- Refactor tests to remove duplication when testing for all possible values in fc7974db0c69d54b5eb10f6f6ceeca262d155404

