### PR TITLE
Fixing the gcloud service list command example

### DIFF
--- a/website/docs/r/google_project_service.html.markdown
+++ b/website/docs/r/google_project_service.html.markdown
@@ -12,7 +12,7 @@ description: |-
 Allows management of a single API service for an existing Google Cloud Platform project. 
 
 For a list of services available, visit the
-[API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
+[API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list --available`.
 
 Requires [Service Usage API](https://console.cloud.google.com/apis/library/serviceusage.googleapis.com).
 


### PR DESCRIPTION
From the man page:

```
    This command lists the services that are enabled or available to be enabled
    by a project. You can choose the mode in which the command will list
    services by using exactly one of the --enabled or --available flags.
    --enabled is the default.
```

So running `gcloud service list` without any args will result in list of services already enabled

```release-note:none
```