### PR TITLE
Fix dns_managed_zone's dnssec_config block formatting

### DIFF
--- a/website/docs/r/dns_managed_zone.html.markdown
+++ b/website/docs/r/dns_managed_zone.html.markdown
@@ -289,6 +289,7 @@ The following arguments are supported:
     If it is not provided, the provider project is used.
 
 * `force_destroy` - (Optional) Set this true to delete all records in the zone.
+
 The `dnssec_config` block supports:
 
 * `kind` -


### PR DESCRIPTION
This fixes the `dnssec_config` block description section to match the typical formatting for a block description. Currently it isn't separated correctly from its the previous section.