### PR TITLE
Add MQL based alerting policies

### DIFF
--- a/google/resource_monitoring_alert_policy.go
+++ b/google/resource_monitoring_alert_policy.go
@@ -1303,8 +1303,8 @@ func flattenMonitoringAlertPolicyConditionsConditionMQL(v interface{}, d *schema
 	if v == nil {
 		return nil
 	}
-	original := v.(map[string]interface{})
-	if len(original) == 0 {
+	original, ok := v.(map[string]interface{})
+	if !ok || len(original) == 0 {
 		return nil
 	}
 	transformed := make(map[string]interface{})
@@ -1329,8 +1329,8 @@ func flattenMonitoringAlertPolicyConditionsConditionMQLTrigger(v interface{}, d 
 	if v == nil {
 		return nil
 	}
-	original := v.(map[string]interface{})
-	if len(original) == 0 {
+	original, ok := v.(map[string]interface{})
+	if !ok || len(original) == 0 {
 		return nil
 	}
 	transformed := make(map[string]interface{})

--- a/google/resource_monitoring_alert_policy_test.go
+++ b/google/resource_monitoring_alert_policy_test.go
@@ -16,6 +16,7 @@ func TestAccMonitoringAlertPolicy(t *testing.T) {
 		"basic":  testAccMonitoringAlertPolicy_basic,
 		"full":   testAccMonitoringAlertPolicy_full,
 		"update": testAccMonitoringAlertPolicy_update,
+		"mql":    testAccMonitoringAlertPolicy_mql,
 	}
 
 	for name, tc := range testCases {
@@ -103,6 +104,28 @@ func testAccMonitoringAlertPolicy_full(t *testing.T) {
 			},
 			{
 				ResourceName:      "google_monitoring_alert_policy.full",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccMonitoringAlertPolicy_mql(t *testing.T) {
+
+	alertName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	conditionName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlertPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitoringAlertPolicy_mqlCfg(alertName, conditionName),
+			},
+			{
+				ResourceName:      "google_monitoring_alert_policy.mql",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -225,4 +248,32 @@ resource "google_monitoring_alert_policy" "full" {
   }
 }
 `, alertName, conditionName1, conditionName2)
+}
+
+func testAccMonitoringAlertPolicy_mqlCfg(alertName, conditionName string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_alert_policy" "mql" {
+  display_name = "%s"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "%s"
+
+    condition_mql {
+      query           = "fetch gce_instance::compute.googleapis.com/instance/cpu/utilization | align mean_aligner() | window 5m | condition value.utilization > .15 '10^2.%%'"
+      duration        = "60s"
+
+      trigger {
+        count = 2
+      }
+    }
+  }
+
+  documentation {
+    content   = "test content"
+    mime_type = "text/markdown"
+  }
+}
+`, alertName, conditionName)
 }

--- a/website/docs/r/monitoring_alert_policy.html.markdown
+++ b/website/docs/r/monitoring_alert_policy.html.markdown
@@ -96,6 +96,12 @@ The `conditions` block supports:
   continues to receive new data points.
   Structure is documented below.
 
+* `condition_mql` -
+  (Optional)
+  A condition that checks the boolean stream
+  output of a Monitoring Query Language
+  query.  Structure is documented below.
+
 * `name` -
   The unique resource name for this condition.
   Its syntax is:
@@ -270,6 +276,41 @@ The `trigger` block supports:
   The absolute number of time series
   that must fail the predicate for the
   condition to be triggered.
+
+The `condition_mql` block supports:
+
+* `query` -
+  (Required)
+  Monitoring Query Language query that
+  outputs a boolean stream.
+
+* `trigger` -
+  (Optional)
+  The number/percent of time series for which
+  the comparison must hold in order for the
+  condition to trigger. If unspecified, then
+  the condition will trigger if the comparison
+  is true for any of the time series that have
+  been identified by filter and aggregations.
+  Structure is documented below.
+
+* `duration` -
+  (Required)
+  The amount of time that a time series must
+  violate the threshold to be considered
+  failing. Currently, only values that are a
+  multiple of a minute--e.g., 0, 60, 120, or
+  300 seconds--are supported. If an invalid
+  value is given, an error will be returned.
+  When choosing a duration, it is useful to
+  keep in mind the frequency of the
+  underlying time series data (which may also
+  be affected by any alignments specified in
+  the aggregations field); a good duration is
+  long enough so that a single outlier does
+  not generate spurious alerts, but short
+  enough that unhealthy states are detected
+  and alerted on quickly.
 
 The `condition_threshold` block supports:
 


### PR DESCRIPTION
Fixes #7464

* Names the key within the `conditions` block as `condition_mql`
* Requires MQL queries to be in the [strict form](https://cloud.google.com/monitoring/mql/query-language#strict-v-concise) as they are sent verbatim.