### PR TITLE
Update bigquery_dataset.html.markdown

### DIFF
--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -259,7 +259,7 @@ The `default_encryption_configuration` block supports:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `id` - an identifier for the resource with format `projects/{{project}}/datasets/{{dataset_id}}`
+* `id` - an identifier for the resource with format `{{project_id}}:{{dataset_id}}`
 
 * `creation_time` -
   The time when this dataset was created, in milliseconds since the


### PR DESCRIPTION
Correcting bigquery dataset id attribute output format. 
Output returned is `{{project_id}}:{{dataset_id}}`