### PR TITLE
Updated docs for switching to/from google-beta

### DIFF
--- a/website/docs/guides/provider_versions.html.markdown
+++ b/website/docs/guides/provider_versions.html.markdown
@@ -119,11 +119,26 @@ terraform import google_compute_instance.beta-instance my-instance
 
 Resources can safely be converted from one version to the other without needing to rebuild infrastructure.
 
-To go from GA to beta, change the `provider` field from `"google"` to `"google-beta"`.
+To go from GA to beta:
+
+1. Change the `provider` field from `"google"` to `"google-beta"`.
+1. Migrate the Terraform state of your existing infrastructure, to migrate the ownership of existing resources from the `"google"` provider to the `"google-beta"` provider. For example, the following command will migrate all existing resources in the Terraform state that used the `"google"` provider to use the `"google-beta"` provider instead: 
+    
+    ```bash
+    terraform state replace-provider registry.terraform.io/hashicorp/google registry.terraform.io/hashicorp/google-beta
+    ```
+
+1. (Optional) Run  `terraform plan` or `terraform refresh`+`terraform show` to verify that the migrated Terraform configuration and state result in a correct plan (e.g. typically "Plan: 0 to add, 0 to change, 0 to destroy."), and that beta-only fields are added to the state.
 
 To go from beta to GA, do the reverse. If you were previously using beta fields that you no longer wish to use:
 
 1. (Optional) Explicitly set the fields back to their default values in your Terraform config file, and run `terraform apply`.
 1. Change the `provider` field to `"google"`.
 1. Remove any beta fields from your Terraform config.
+1. Migrate the Terraform state of your existing infrastructure, to migrate the ownership of existing resources from the `"google-beta"` provider to the `"google"` provider. For example, the following command will migrate all existing resources in the Terraform state that used the `"google-beta"` provider to use the `"google"` provider instead: 
+    
+    ```bash
+    terraform state replace-provider registry.terraform.io/hashicorp/google-beta registry.terraform.io/hashicorp/google
+    ```
+
 1. Run  `terraform plan` or `terraform refresh`+`terraform show` to see that the beta fields are no longer in state.


### PR DESCRIPTION
The "Resources can safely be converted from one version to the other without needing to rebuild infrastructure." statement and associated migration steps in the previous docs appears to be inaccurate as of Terraform v0.13.

Following the previously documented instructions for switching existing resources to use the google-beta provider resulted in `terraform plan` that attempted to destroy (using the google provider) all existing resources and to (re)create new instances of each resource (using the google-beta provider), instead of a no-op plan.

Also, if the existing provider's type was changed (rather than adding a new, separate provider, while retaining the old provider) in the Terraform configuration, then `terraform refresh` would also result in errors similar to the following:

```
Error: Provider configuration not present

To work with
google_compute_RESOURCE_TYPE.RESOURCE-NAME
its original provider configuration at
provider["registry.terraform.io/hashicorp/google"].PROVIDER-ALIAS
is required, but it has been removed. This occurs when a provider
configuration is removed while objects created by that provider still exist in
the state. Re-add the provider configuration to destroy
google_compute_RESOURCE_TYPE.RESOURCE-NAME,
after which you can remove the provider configuration again.
```

This new/undocumented behavior when switching between the google and google-beta providers appears to be related to changes in Terraform v0.12 and v0.13 that affected the way in which providers are referenced within the Terraform state data.