### PR TITLE
Compute: add support for instance reservation_affinity

### DIFF
--- a/google/compute_instance_helpers.go
+++ b/google/compute_instance_helpers.go
@@ -377,3 +377,54 @@ func schedulingHasChange(d *schema.ResourceData) bool {
 
 	return reflect.DeepEqual(newNa, originalNa)
 }
+
+func expandReservationAffinity(d *schema.ResourceData) (*computeBeta.ReservationAffinity, error) {
+	_, ok := d.GetOk("reservation_affinity")
+	if !ok {
+		return nil, nil
+	}
+
+	prefix := "reservation_affinity.0"
+	reservationAffinityType := d.Get(prefix + ".type").(string)
+
+	affinity := computeBeta.ReservationAffinity{
+		ConsumeReservationType: reservationAffinityType,
+		ForceSendFields:        []string{"ConsumeReservationType"},
+	}
+
+	_, hasSpecificReservation := d.GetOk(prefix + ".specific_reservation")
+	if (reservationAffinityType == "SPECIFIC_RESERVATION") != hasSpecificReservation {
+		return nil, fmt.Errorf("specific_reservation must be set when reservation_affinity is SPECIFIC_RESERVATION, and not set otherwise")
+	}
+
+	prefix = prefix + ".specific_reservation.0"
+	if hasSpecificReservation {
+		affinity.Key = d.Get(prefix + ".key").(string)
+		affinity.ForceSendFields = append(affinity.ForceSendFields, "Key", "Values")
+
+		for _, v := range d.Get(prefix + ".values").([]interface{}) {
+			affinity.Values = append(affinity.Values, v.(string))
+		}
+	}
+
+	return &affinity, nil
+}
+
+func flattenReservationAffinity(affinity *computeBeta.ReservationAffinity) []map[string]interface{} {
+	if affinity == nil {
+		return nil
+	}
+
+	flattened := map[string]interface{}{
+		"type": affinity.ConsumeReservationType,
+	}
+
+	if affinity.ConsumeReservationType == "SPECIFIC_RESERVATION" {
+		flattened["specific_reservation"] = []map[string]interface{}{{
+			"key":    affinity.Key,
+			"values": affinity.Values,
+		}}
+	}
+
+	return []map[string]interface{}{flattened}
+}

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -708,6 +708,51 @@ func resourceComputeInstance() *schema.Resource {
 				MaxItems:         1,
 				Description:      `A list of short names or self_links of resource policies to attach to the instance. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.`,
 			},
+
+			"reservation_affinity": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the reservations that this instance can consume from.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ANY_RESERVATION", "SPECIFIC_RESERVATION", "NO_RESERVATION"}, false),
+							Description:  `The type of reservation from which this instance can consume resources.`,
+						},
+
+						"specific_reservation": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Specifies the label selector for the reservation to use.`,
+
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify compute.googleapis.com/reservation-name as the key and specify the name of your reservation as the only value.`,
+									},
+									"values": {
+										Type:        schema.TypeList,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label values of a reservation resource.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		CustomizeDiff: customdiff.All(
 			customdiff.If(
@@ -825,6 +870,11 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *Confi
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
+	reservationAffinity, err := expandReservationAffinity(d)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
+	}
+
 	// Create the instance information
 	return &computeBeta.Instance{
 		CanIpForward:           d.Get("can_ip_forward").(bool),
@@ -845,6 +895,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *Confi
 		ForceSendFields:        []string{"CanIpForward", "DeletionProtection"},
 		ShieldedInstanceConfig: expandShieldedVmConfigs(d),
 		DisplayDevice:          expandDisplayDevice(d),
+		ReservationAffinity:    reservationAffinity,
 		ResourcePolicies:       convertStringArr(d.Get("resource_policies").([]interface{})),
 	}, nil
 }
@@ -1200,6 +1251,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 		if err := d.Set("desired_status", instance.Status); err != nil {
 			return fmt.Errorf("Error setting desired_status: %s", err)
 		}
+	}
+	if err := d.Set("reservation_affinity", flattenReservationAffinity(instance.ReservationAffinity)); err != nil {
+		return fmt.Errorf("Error setting reservation_affinity: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance.Name))

--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -572,6 +572,51 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				Set:         schema.HashString,
 				Description: `A set of key/value label pairs to assign to instances created from this template,`,
 			},
+
+			"reservation_affinity": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the reservations that this instance can consume from.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ANY_RESERVATION", "SPECIFIC_RESERVATION", "NO_RESERVATION"}, false),
+							Description:  `The type of reservation from which this instance can consume resources.`,
+						},
+
+						"specific_reservation": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Specifies the label selector for the reservation to use.`,
+
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify compute.googleapis.com/reservation-name as the key and specify the name of your reservation as the only value.`,
+									},
+									"values": {
+										Type:        schema.TypeList,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label values of a reservation resource.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -823,6 +868,11 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
+	reservationAffinity, err := expandReservationAffinity(d)
+	if err != nil {
+		return err
+	}
+
 	instanceProperties := &computeBeta.InstanceProperties{
 		CanIpForward:           d.Get("can_ip_forward").(bool),
 		Description:            d.Get("instance_description").(string),
@@ -837,6 +887,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		Tags:                   resourceInstanceTags(d),
 		ShieldedInstanceConfig: expandShieldedVmConfigs(d),
 		DisplayDevice:          expandDisplayDevice(d),
+		ReservationAffinity:    reservationAffinity,
 	}
 
 	if _, ok := d.GetOk("labels"); ok {
@@ -1224,6 +1275,13 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error setting enable_display: %s", err)
 		}
 	}
+
+	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+			return fmt.Errorf("Error setting reservation_affinity: %s", err)
+		}
+	}
+
 	return nil
 }
 

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -734,6 +734,57 @@ func TestAccComputeInstanceTemplate_soleTenantNodeAffinities(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_reservationAffinities(t *testing.T) {
+	t.Parallel()
+
+	var template computeBeta.InstanceTemplate
+	var templateName = randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "NO_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
+					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "NO_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "ANY_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
+					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "ANY_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "SPECIFIC_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
+					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "SPECIFIC_RESERVATION", templateName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_shieldedVmConfig1(t *testing.T) {
 	t.Parallel()
 
@@ -1181,6 +1232,36 @@ func testAccCheckComputeInstanceTemplateHasMinCpuPlatform(instanceTemplate *comp
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.MinCpuPlatform != minCpuPlatform {
 			return fmt.Errorf("Wrong minimum CPU platform: expected %s, got %s", minCpuPlatform, instanceTemplate.Properties.MinCpuPlatform)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceTemplateHasReservationAffinity(instanceTemplate *computeBeta.InstanceTemplate, consumeReservationType string, specificReservationNames ...string) resource.TestCheckFunc {
+	if len(specificReservationNames) > 1 {
+		panic("too many specificReservationNames in test")
+	}
+
+	return func(*terraform.State) error {
+		if instanceTemplate.Properties.ReservationAffinity == nil {
+			return fmt.Errorf("expected template to have reservation affinity, but it was nil")
+		}
+
+		if actualReservationType := instanceTemplate.Properties.ReservationAffinity.ConsumeReservationType; actualReservationType != consumeReservationType {
+			return fmt.Errorf("Wrong reservationAffinity consumeReservationType: expected %s, got, %s", consumeReservationType, actualReservationType)
+		}
+
+		if len(specificReservationNames) > 0 {
+			const reservationNameKey = "compute.googleapis.com/reservation-name"
+			if actualKey := instanceTemplate.Properties.ReservationAffinity.Key; actualKey != reservationNameKey {
+				return fmt.Errorf("Wrong reservationAffinity key: expected %s, got, %s", reservationNameKey, actualKey)
+			}
+
+			reservationAffinityValues := instanceTemplate.Properties.ReservationAffinity.Values
+			if len(reservationAffinityValues) != 1 || reservationAffinityValues[0] != specificReservationNames[0] {
+				return fmt.Errorf("Wrong reservationAffinity values: expected %s, got, %s", specificReservationNames, reservationAffinityValues)
+			}
 		}
 
 		return nil
@@ -2037,6 +2118,47 @@ resource "google_compute_instance_template" "foobar" {
   }
 }
 `, suffix)
+}
+
+func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, consumeReservationType string) string {
+	var reservationInstanceCfgSection string
+
+	if consumeReservationType == "SPECIFIC_RESERVATION" {
+		reservationInstanceCfgSection = fmt.Sprintf(`
+	specific_reservation {
+		key = "compute.googleapis.com/reservation-name"
+		values = ["%s"]
+	}`, templateName)
+	}
+
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "instancet-test-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "%s"
+
+    %s
+  }
+}
+`, templateName, consumeReservationType, reservationInstanceCfgSection)
 }
 
 func testAccComputeInstanceTemplate_shieldedVmConfig(suffix string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -856,6 +856,45 @@ func TestAccComputeInstance_soleTenantNodeAffinities(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_reservationAffinities(t *testing.T) {
+	t.Parallel()
+
+	var instance computeBeta.Instance
+	var instanceName = fmt.Sprintf("tf-test-resaffinity-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_reservationAffinityConfig(instanceName, "NO_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasReservationAffinity(&instance, "NO_RESERVATION"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			{
+				Config: testAccComputeInstance_reservationAffinityConfig(instanceName, "ANY_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasReservationAffinity(&instance, "ANY_RESERVATION"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			{
+				Config: testAccComputeInstance_reservationAffinityConfig(instanceName, "SPECIFIC_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasReservationAffinity(&instance, "SPECIFIC_RESERVATION", instanceName),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+		},
+	})
+}
+
 func TestAccComputeInstance_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -2562,6 +2601,34 @@ func testAccCheckComputeInstanceHasConfiguredDeletionProtection(instance *comput
 	return func(s *terraform.State) error {
 		if instance.DeletionProtection != configuredDeletionProtection {
 			return fmt.Errorf("Wrong deletion protection flag: expected %t, got %t", configuredDeletionProtection, instance.DeletionProtection)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceHasReservationAffinity(instance *computeBeta.Instance, reservationType string, specificReservationNames ...string) resource.TestCheckFunc {
+	if len(specificReservationNames) > 1 {
+		panic("too many specificReservationNames provided in test")
+	}
+
+	return func(*terraform.State) error {
+		if instance.ReservationAffinity == nil {
+			return fmt.Errorf("expected instance to have reservation affinity, but it was nil")
+		}
+
+		if instance.ReservationAffinity.ConsumeReservationType != reservationType {
+			return fmt.Errorf("Wrong reservationAffinity consumeReservationType: expected %s, got, %s", reservationType, instance.ReservationAffinity.ConsumeReservationType)
+		}
+
+		if len(specificReservationNames) > 0 {
+			const reservationNameKey = "compute.googleapis.com/reservation-name"
+			if instance.ReservationAffinity.Key != reservationNameKey {
+				return fmt.Errorf("Wrong reservationAffinity key: expected %s, got, %s", reservationNameKey, instance.ReservationAffinity.Key)
+			}
+			if len(instance.ReservationAffinity.Values) != 1 || instance.ReservationAffinity.Values[0] != specificReservationNames[0] {
+				return fmt.Errorf("Wrong reservationAffinity values: expected %s, got, %s", specificReservationNames, instance.ReservationAffinity.Values)
+			}
 		}
 
 		return nil
@@ -4558,6 +4625,63 @@ resource "google_compute_node_group" "nodes" {
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 `, instance, nodeTemplate, nodeGroup)
+}
+
+func testAccComputeInstance_reservationAffinityConfig(instanceName, reservationType string) string {
+	var reservationCfg, reservationInstanceCfgSection string
+
+	if reservationType == "SPECIFIC_RESERVATION" {
+		reservationCfg = fmt.Sprintf(`
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type = "n1-standard-1"
+    }
+  }
+
+  specific_reservation_required = true
+}`, instanceName)
+
+		reservationInstanceCfgSection = fmt.Sprintf(`
+	specific_reservation {
+		key = "compute.googleapis.com/reservation-name"
+		values = ["%s"]
+	}`, instanceName)
+	}
+
+	instanceCfg := fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "%s"
+
+    %s
+  }
+}`, instanceName, reservationType, reservationInstanceCfgSection)
+
+	return strings.Join([]string{reservationCfg, instanceCfg}, "\n")
 }
 
 func testAccComputeInstance_shieldedVmConfig(instance string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -144,6 +144,10 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
+* `reservation_affinity` – (Optional) Specify whether the resources for the instance
+    should be [consumed from a reservation](https://cloud.google.com/compute/docs/instances/reserving-zonal-resources#consuming_reserved_instances).
+    Structure is documented below.
+
 * `scheduling` - (Optional) The scheduling strategy to use. More details about
     this configuration option are detailed below.
 
@@ -292,6 +296,22 @@ The `alias_ip_range` block supports:
 * `subnetwork_range_name` - (Optional) The subnetwork secondary range name specifying
     the secondary range from which to allocate the IP CIDR range for this alias IP
     range. If left unspecified, the primary range of the subnetwork will be used.
+
+The `reservation_affinity` block supports:
+
+* `type` – The method for matching a reservation affinity for this instance.
+    This field can take the following values: ANY_RESERVATION, SPECIFIC_RESERVATION,
+    NO_RESERVATION. If this field is not specified, it is assumed to be ANY_RESERVATION.
+
+* `specific_reservation` – (Optional) Properties of the reservation to use. This field
+    must be set if and only if `type` is SPECIFIC_RESERVATION. Structure is documented below.
+
+The `specific_reservation` block supports:
+
+* `key` – The key to use for matching the reservation. To match a reservation by name, use the
+    special key `compute.googleapis.com/reservation-name`.
+
+* `values` – A list of values corresponding to the supplied `key`. At least one must be supplied.
 
 The `service_account` block supports:
 

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -229,6 +229,10 @@ The following arguments are supported:
     resource is tied to a specific region. Defaults to the region of the
     Provider if no value is given.
 
+* `reservation_affinity` – (Optional) Specify whether the resources for the instance
+    should be [consumed from a reservation](https://cloud.google.com/compute/docs/instances/reserving-zonal-resources#consuming_reserved_instances).
+    Structure is documented below.
+
 * `scheduling` - (Optional) The scheduling strategy to use. More details about
     this configuration option are detailed below.
 
@@ -353,6 +357,22 @@ The `alias_ip_range` block supports:
 * `subnetwork_range_name` - (Optional) The subnetwork secondary range name specifying
     the secondary range from which to allocate the IP CIDR range for this alias IP
     range. If left unspecified, the primary range of the subnetwork will be used.
+
+The `reservation_affinity` block supports:
+
+* `type` – The method for matching a reservation affinity for this instance.
+    This field can take the following values: ANY_RESERVATION, SPECIFIC_RESERVATION,
+    NO_RESERVATION. If this field is not specified, it is assumed to be ANY_RESERVATION.
+
+* `specific_reservation` – (Optional) Properties of the reservation to use. This field
+    must be set if and only if `type` is SPECIFIC_RESERVATION. Structure is documented below.
+
+The `specific_reservation` block supports:
+
+* `key` – The key to use for matching the reservation. To match a reservation by name, use the
+    special key `compute.googleapis.com/reservation-name`.
+
+* `values` – A list of values corresponding to the supplied `key`. At least one must be supplied.
 
 The `service_account` block supports:
 


### PR DESCRIPTION
reservation_affinity controls how instances or instances created from
templates consume Compute Engine resource reservations.

Closes #4593