### PR TITLE
Use correct headers: should refer to dataproc, not pubsub

### DIFF
--- a/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage IAM policies on dataproc clusters. Eac
 
 ~> **Note:** `google_dataproc_cluster_iam_binding` resources **can be** used in conjunction with `google_dataproc_cluster_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_pubsub\_subscription\_iam\_policy
+## google\_dataproc\_cluster\_iam\_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -39,7 +39,7 @@ resource "google_dataproc_cluster_iam_policy" "editor" {
 }
 ```
 
-## google\_pubsub\_subscription\_iam\_binding
+## google\_dataproc\_cluster\_iam\_binding
 
 ```hcl
 resource "google_dataproc_cluster_iam_binding" "editor" {
@@ -51,7 +51,7 @@ resource "google_dataproc_cluster_iam_binding" "editor" {
 }
 ```
 
-## google\_pubsub\_subscription\_iam\_member
+## google\_dataproc\_cluster\_iam\_member
 
 ```hcl
 resource "google_dataproc_cluster_iam_member" "editor" {


### PR DESCRIPTION
On the documentation page of [`google_dataproc_cluster_iam`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_cluster_iam), the headers are mentioning pubsub (e.g. `google_pubsub_subscription_iam_policy`). The examples are correct, it's just the headers that are wrong.

Closes #7670 .