### PR TITLE
Since beta provider isn't /really/ recent.. removing recent adjective

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Using the provider
 See the [Google Provider documentation](https://www.terraform.io/docs/providers/google/index.html) to get started using the
 Google provider.
 
-We also maintain 'google-beta' provider for preview features, and features at a beta [launch stage](https://cloud.google.com/products#product-launch-stages). See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
+We also maintain the 'google-beta' provider for preview features and features at a beta [launch stage](https://cloud.google.com/products#product-launch-stages). See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
 for more details on how to use `google-beta`.
 
 Upgrading the provider

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Using the provider
 See the [Google Provider documentation](https://www.terraform.io/docs/providers/google/index.html) to get started using the
 Google provider.
 
-We recently introduced the `google-beta` provider. See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
+We also maintain `google-beta` provider for unstable and experimental features. See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
 for more details on how to use `google-beta`.
 
 Upgrading the provider

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Using the provider
 See the [Google Provider documentation](https://www.terraform.io/docs/providers/google/index.html) to get started using the
 Google provider.
 
-We also maintain `google-beta` provider for unstable and experimental features. See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
+We also maintain 'google-beta' provider for preview features, and features at a beta [launch stage](https://cloud.google.com/products#product-launch-stages). See [Provider Versions](https://www.terraform.io/docs/providers/google/provider_versions.html)
 for more details on how to use `google-beta`.
 
 Upgrading the provider


### PR DESCRIPTION
Updating `README.md` to rephrase how we refer to the beta provider 