### PR TITLE
Feature: Adds new restore_policy on google_project_default_service_accounts

### DIFF
--- a/google/resource_google_project_default_service_accounts.go
+++ b/google/resource_google_project_default_service_accounts.go
@@ -52,7 +52,7 @@ func resourceGoogleProjectDefaultServiceAccounts() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"NONE", "REVERT", "REVERT_AND_IGNORE_FAILURE"}, false),
 				Description: `The action to be performed in the default service accounts on the resource destroy.
 				Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.
-				If set to REVERT it attemps to restore all default SAs but the DEPRIVILEGE action.
+				If set to REVERT it attempts to restore all default SAs but the DEPRIVILEGE action.
 				If set to REVERT_AND_IGNORE_FAILURE it is the same behavior as REVERT but ignores errors returned by the API.`,
 			},
 			"service_accounts": {

--- a/google/resource_google_project_default_service_accounts.go
+++ b/google/resource_google_project_default_service_accounts.go
@@ -51,7 +51,9 @@ func resourceGoogleProjectDefaultServiceAccounts() *schema.Resource {
 				Default:      "REVERT",
 				ValidateFunc: validation.StringInSlice([]string{"NONE", "REVERT", "REVERT_AND_IGNORE_FAILURE"}, false),
 				Description: `The action to be performed in the default service accounts on the resource destroy.
-				Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.`,
+				Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.
+				If set to REVERT it attemps to restore all default SAs but the DEPRIVILEGE action.
+				If set to REVERT_AND_IGNORE_FAILURE it is the same behavior as REVERT but ignores errors returned by the API.`,
 			},
 			"service_accounts": {
 				Type:        schema.TypeMap,
@@ -81,8 +83,8 @@ func resourceGoogleProjectDefaultServiceAccountsDoAction(d *schema.ResourceData,
 		errExpected := restorePolicy == "REVERT_AND_IGNORE_FAILURE"
 		errReceived := err != nil
 		if errExpected && errReceived {
-			log.Printf("cannot undelete service account %s: %v", serviceAccountSelfLink, err)
-			log.Printf("restore policy is %s... ignoring error", restorePolicy)
+			log.Printf("[DEBUG] cannot undelete service account %s: %v", serviceAccountSelfLink, err)
+			log.Printf("[WARNING] restore policy is %s... ignoring error", restorePolicy)
 		}
 		if !errExpected && errReceived {
 			return fmt.Errorf("cannot undelete service account %s: %v", serviceAccountSelfLink, err)
@@ -97,8 +99,8 @@ func resourceGoogleProjectDefaultServiceAccountsDoAction(d *schema.ResourceData,
 		errReceived := err != nil
 		errExpected := restorePolicy == "REVERT_AND_IGNORE_FAILURE"
 		if errExpected && errReceived {
-			log.Printf("cannot enable service account %s: %v", serviceAccountSelfLink, err)
-			log.Printf("restore policy is %s... ignoring error", restorePolicy)
+			log.Printf("[DEBUG] cannot enable service account %s: %v", serviceAccountSelfLink, err)
+			log.Printf("[WARNING] restore policy is %s... ignoring error", restorePolicy)
 		}
 		if !errExpected && errReceived {
 			return fmt.Errorf("cannot enable service account %s: %v", serviceAccountSelfLink, err)

--- a/google/resource_google_project_default_service_accounts_test.go
+++ b/google/resource_google_project_default_service_accounts_test.go
@@ -109,6 +109,34 @@ func TestAccResourceGoogleProjectDefaultServiceAccountsDelete(t *testing.T) {
 	})
 }
 
+func TestAccResourceGoogleProjectDefaultServiceAccountsDeleteRevertIgnoreFailure(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	project := fmt.Sprintf("tf-project-%d", randInt(t))
+	billingAccount := getTestBillingAccountFromEnv(t)
+	action := "DELETE"
+	restorePolicy := "REVERT_AND_IGNORE_FAILURE"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectDefaultServiceAccountsAdvanced(org, project, billingAccount, action, restorePolicy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "id", "projects/"+project),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "action", action),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					sleepInSecondsForTest(10),
+					testAccCheckGoogleProjectDefaultServiceAccountsChanges(t, project, action),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceGoogleProjectDefaultServiceAccountsDeprivilege(t *testing.T) {
 	t.Parallel()
 

--- a/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -44,7 +44,10 @@ The following arguments are supported:
 
 - `action` - (Required) The action to be performed in the default service accounts. Valid values are: `DEPRIVILEGE`, `DELETE`, `DISABLE`. Note that `DEPRIVILEGE` action will ignore the REVERT configuration in the restore_policy
 
-- `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy. Valid values are `NONE` and `REVERT`. If set to `REVERT` it will attempt to restore all default SAs but in the `DEPRIVILEGE` action.
+- `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy.
+  Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.
+  If set to REVERT it attempt to restore all default SAs but the DEPRIVILEGE action.
+  If set to REVERT_AND_IGNORE_FAILURE it is the same behavior as REVERT but ignores errors returned by the API.
 
 ## Attributes Reference
 

--- a/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 - `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy.
   Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.
-  If set to REVERT it attempt to restore all default SAs but the DEPRIVILEGE action.
+  If set to REVERT it attempts to restore all default SAs but the DEPRIVILEGE action.
   If set to REVERT_AND_IGNORE_FAILURE it is the same behavior as REVERT but ignores errors returned by the API.
 
 ## Attributes Reference


### PR DESCRIPTION
Adds new `restore_policy REVERT_AND_IGNORE_FAILURE` in order to ignore the errors returned on the revert during the resource destroy