### PR TITLE
Add description and disabled fields to logging sinks

### DIFF
--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -83,6 +83,64 @@ func TestAccLoggingBillingAccountSink_update(t *testing.T) {
 	}
 }
 
+func TestAccLoggingBillingAccountSink_described(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+	billingAccount := getTestBillingAccountFromEnv(t)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingBillingAccountSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBillingAccountSink_described(sinkName, bucketName, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingBillingAccountSinkExists(t, "google_logging_billing_account_sink.described", &sink),
+					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.described"),
+				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.described",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLoggingBillingAccountSink_disabled(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+	billingAccount := getTestBillingAccountFromEnv(t)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingBillingAccountSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBillingAccountSink_disabled(sinkName, bucketName, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingBillingAccountSinkExists(t, "google_logging_billing_account_sink.disabled", &sink),
+					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.disabled"),
+				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingBillingAccountSink_updateBigquerySink(t *testing.T) {
 	t.Parallel()
 
@@ -209,6 +267,36 @@ func testAccCheckLoggingBillingAccountSink(sink *logging.LogSink, n string) reso
 func testAccLoggingBillingAccountSink_basic(name, bucketName, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_logging_billing_account_sink" "basic" {
+  name            = "%s"
+  billing_account = "%s"
+  destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, billingAccount, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingBillingAccountSink_described(name, bucketName, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_logging_billing_account_sink" "described" {
+  name            = "%s"
+  billing_account = "%s"
+  destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, billingAccount, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingBillingAccountSink_disabled(name, bucketName, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_logging_billing_account_sink" "disabled" {
   name            = "%s"
   billing_account = "%s"
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"

--- a/google/resource_logging_billing_account_sink_test.go
+++ b/google/resource_logging_billing_account_sink_test.go
@@ -286,6 +286,7 @@ resource "google_logging_billing_account_sink" "described" {
   billing_account = "%s"
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  description     = "this is a description for a billing account level logging sink"
 }
 
 resource "google_storage_bucket" "log-bucket" {
@@ -301,6 +302,7 @@ resource "google_logging_billing_account_sink" "disabled" {
   billing_account = "%s"
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  disabled        = true
 }
 
 resource "google_storage_bucket" "log-bucket" {

--- a/google/resource_logging_organization_sink_test.go
+++ b/google/resource_logging_organization_sink_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/logging/v2"
-	"strconv"
 )
 
 func TestAccLoggingOrganizationSink_basic(t *testing.T) {
@@ -82,6 +83,64 @@ func TestAccLoggingOrganizationSink_update(t *testing.T) {
 		t.Errorf("Expected WriterIdentity to be the same, but it differs: before = %#v, after = %#v",
 			sinkBefore.WriterIdentity, sinkAfter.WriterIdentity)
 	}
+}
+
+func TestAccLoggingOrganizationSink_described(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingOrganizationSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingOrganizationSink_described(sinkName, bucketName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingOrganizationSinkExists(t, "google_logging_organization_sink.described", &sink),
+					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.described"),
+				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.described",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLoggingOrganizationSink_disabled(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingOrganizationSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingOrganizationSink_disabled(sinkName, bucketName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingOrganizationSinkExists(t, "google_logging_organization_sink.disabled", &sink),
+					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.disabled"),
+				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func TestAccLoggingOrganizationSink_updateBigquerySink(t *testing.T) {
@@ -242,6 +301,42 @@ resource "google_logging_organization_sink" "update" {
   destination      = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   include_children = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, sinkName, orgId, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingOrganizationSink_described(sinkName, bucketName, orgId string) string {
+	return fmt.Sprintf(`
+resource "google_logging_organization_sink" "described" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  description = "this is a description for an organization level logging sink"
+
+  unique_writer_identity = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, sinkName, orgId, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingOrganizationSink_disabled(sinkName, bucketName, orgId string) string {
+	return fmt.Sprintf(`
+resource "google_logging_organization_sink" "disabled" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  disabled    = true
+
+  unique_writer_identity = false
 }
 
 resource "google_storage_bucket" "log-bucket" {

--- a/google/resource_logging_project_sink_test.go
+++ b/google/resource_logging_project_sink_test.go
@@ -31,6 +31,52 @@ func TestAccLoggingProjectSink_basic(t *testing.T) {
 	})
 }
 
+func TestAccLoggingProjectSink_described(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_described(sinkName, getTestProjectFromEnv(), bucketName),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.described",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLoggingProjectSink_disabled(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_disabled(sinkName, getTestProjectFromEnv(), bucketName),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingProjectSink_updatePreservesUniqueWriter(t *testing.T) {
 	t.Parallel()
 
@@ -167,6 +213,42 @@ resource "google_logging_project_sink" "basic" {
   project     = "%s"
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+
+  unique_writer_identity = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, project, project, bucketName)
+}
+
+func testAccLoggingProjectSink_described(name, project, bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "described" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  description = "this is a description for a project level logging sink"
+
+  unique_writer_identity = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, project, project, bucketName)
+}
+
+func testAccLoggingProjectSink_disabled(name, project, bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "disabled" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  disabled    = true
 
   unique_writer_identity = false
 }

--- a/google/resource_logging_sink.go
+++ b/google/resource_logging_sink.go
@@ -30,6 +30,18 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 			Description:      `The filter to apply when exporting logs. Only log entries that match the filter are exported.`,
 		},
 
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `A description of this sink. The maximum length of the description is 8000 characters.`,
+		},
+
+		"disabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: `If set to True, then this sink is disabled and it does not export any log entries.`,
+		},
+
 		"exclusions": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -97,6 +109,8 @@ func expandResourceLoggingSink(d *schema.ResourceData, resourceType, resourceId 
 		Name:            d.Get("name").(string),
 		Destination:     d.Get("destination").(string),
 		Filter:          d.Get("filter").(string),
+		Description:     d.Get("description").(string),
+		Disabled:        d.Get("disabled").(bool),
 		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
 		BigqueryOptions: expandLoggingSinkBigqueryOptions(d.Get("bigquery_options")),
 	}
@@ -112,6 +126,12 @@ func flattenResourceLoggingSink(d *schema.ResourceData, sink *logging.LogSink) e
 	}
 	if err := d.Set("filter", sink.Filter); err != nil {
 		return fmt.Errorf("Error setting filter: %s", err)
+	}
+	if err := d.Set("description", sink.Description); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("disabled", sink.Disabled); err != nil {
+		return fmt.Errorf("Error setting disabled: %s", err)
 	}
 	if err := d.Set("writer_identity", sink.WriterIdentity); err != nil {
 		return fmt.Errorf("Error setting writer_identity: %s", err)
@@ -141,6 +161,12 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.L
 	}
 	if d.HasChange("filter") {
 		updateFields = append(updateFields, "filter")
+	}
+	if d.HasChange("description") {
+		updateFields = append(updateFields, "description")
+	}
+	if d.HasChange("disabled") {
+		updateFields = append(updateFields, "disabled")
 	}
 	if d.HasChange("exclusions") {
 		sink.Exclusions = expandLoggingSinkExclusions(d.Get("exclusions"))


### PR DESCRIPTION
While doing some work with analyzing logs, higher priority tasks came up, and it was useful to be able to temporarily disable the log sink when not working on the analysis task(s). I noticed `disabled` (and then `description` as well) were missing from the Terraform resource schemas compared to the GCP API.

In short: all this PR does is add `description` and `disabled` fields to the logging sink (project, folder, organization, and billing account) schemas. Tests for these new fields are included.