### PR TITLE
docs(kms-crypto-key): fix wrong import format

### DIFF
--- a/website/docs/r/kms_crypto_key.html.markdown
+++ b/website/docs/r/kms_crypto_key.html.markdown
@@ -168,8 +168,8 @@ This resource provides the following
 CryptoKey can be imported using any of these accepted formats:
 
 ```
-$ terraform import google_kms_crypto_key.default {{key_ring}}/cryptoKeys/{{name}}
-$ terraform import google_kms_crypto_key.default {{key_ring}}/{{name}}
+$ terraform import google_kms_crypto_key.default {{project_id}}/{{location_id}}/{{key_ring}}/{{name}}
+$ terraform import google_kms_crypto_key.default {{location_id}}/{{key_ring}}/{{name}}
 ```
 
 ## User Project Overrides


### PR DESCRIPTION
Fixes wrong import format missing location, project name:

```
Error: Invalid CryptoKey id format, expecting `{projectId}/{locationId}/{KeyringName}/{cryptoKeyName}` or `{locationId}/{keyRingName}/{cryptoKeyName}, got id: mykeyring/mytoken
```