### PR TITLE
docs(google_bigquery_table): replaces foo/bar with actual meaninful path

### DIFF
--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -330,5 +330,5 @@ exported:
 BigQuery tables can be imported using the `project`, `dataset_id`, and `table_id`, e.g.
 
 ```
-$ terraform import google_bigquery_table.default gcp-project/foo/bar
+$ terraform import google_bigquery_table.default projects/{{project}}/datasets/{{dataset}}/tables/{{name}}
 ```


### PR DESCRIPTION
Replaces in the documentation for `resource.google_bigquery_table` a useful importable path.

Signed-off-by: Lorenzo Setale <lorenzo@setale.me>