### PR TITLE
bigtable_gc_policy: Adding support for duration lower than day

### DIFF
--- a/google/resource_bigtable_gc_policy.go
+++ b/google/resource_bigtable_gc_policy.go
@@ -58,13 +58,13 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Description:  `GC policy that applies to all cells older than the given age.`,
-				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.seconds"},
+				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"days": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Deprecated:  "Deprecated in favor of seconds",
+							Deprecated:  "Deprecated in favor of duration",
 							Description: `Number of days before applying GC policy.`,
 						},
 						"duration": {
@@ -271,10 +271,12 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 }
 
 func getMaxAgeDuration(values map[string]interface{}) (time.Duration, error) {
-	d := values["seconds"].(string)
-	if d == "" {
-		d = values["days"].(string)
+	d := values["duration"].(string)
+	if d != "" {
+		return time.ParseDuration(d)
 	}
 
-	return time.ParseDuration(d)
+	days := values["days"].(int)
+
+	return time.Hour * 24 * time.Duration(days), nil
 }

--- a/google/resource_bigtable_gc_policy.go
+++ b/google/resource_bigtable_gc_policy.go
@@ -54,24 +54,25 @@ func resourceBigtableGCPolicy() *schema.Resource {
 			},
 
 			"max_age": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				ForceNew:     true,
-				Description:  `GC policy that applies to all cells older than the given age.`,
-				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `GC policy that applies to all cells older than the given age.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"days": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Deprecated:  "Deprecated in favor of duration",
-							Description: `Number of days before applying GC policy.`,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Deprecated:   "Deprecated in favor of duration",
+							Description:  `Number of days before applying GC policy.`,
+							ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
 						},
 						"duration": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Description:  `Duration before applying GC policy`,
 							ValidateFunc: validateDuration(),
+							ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
 						},
 					},
 				},

--- a/google/resource_bigtable_gc_policy.go
+++ b/google/resource_bigtable_gc_policy.go
@@ -62,7 +62,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"days": {
 							Type:        schema.TypeInt,
-							Required:    false,
+							Optional:    true,
 							Deprecated:  "Deprecated in favor of seconds",
 							Description: `Number of days before applying GC policy.`,
 						},

--- a/google/resource_bigtable_gc_policy.go
+++ b/google/resource_bigtable_gc_policy.go
@@ -54,10 +54,10 @@ func resourceBigtableGCPolicy() *schema.Resource {
 			},
 
 			"max_age": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `GC policy that applies to all cells older than the given age.`,
+				Type:         schema.TypeList,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `GC policy that applies to all cells older than the given age.`,
 				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.seconds"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -68,9 +68,9 @@ func resourceBigtableGCPolicy() *schema.Resource {
 							Description: `Number of days before applying GC policy.`,
 						},
 						"duration": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: `Duration before applying GC policy`,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  `Duration before applying GC policy`,
 							ValidateFunc: validateDuration(),
 						},
 					},
@@ -85,9 +85,9 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"number": {
-							Type:        schema.TypeInt,
-							Required:    true,
-							Description: `Number of version before applying the GC policy.`,
+							Type:         schema.TypeInt,
+							Required:     true,
+							Description:  `Number of version before applying the GC policy.`,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},

--- a/google/resource_bigtable_gc_policy_test.go
+++ b/google/resource_bigtable_gc_policy_test.go
@@ -158,7 +158,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "%s"
 
   max_age {
-    seconds = 3600 * 24 * 3
+    duration = "72h"
   }
 }
 `, instanceName, instanceName, tableName, family, family)
@@ -195,7 +195,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    seconds = 3600 * 24 * 3
+    duration = "72h"
   }
 
   max_version {

--- a/google/resource_bigtable_gc_policy_test.go
+++ b/google/resource_bigtable_gc_policy_test.go
@@ -158,7 +158,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "%s"
 
   max_age {
-    days = 3
+    seconds = 3600 * 24 * 3
   }
 }
 `, instanceName, instanceName, tableName, family, family)
@@ -195,7 +195,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    days = 3
+    seconds = 3600 * 24 * 3
   }
 
   max_version {

--- a/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/website/docs/r/bigtable_gc_policy.html.markdown
@@ -42,7 +42,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "name"
 
   max_age {
-    seconds = 3600 * 24 * 7 # 7 days
+    duration = "168h" # 7 days
   }
 }
 ```
@@ -58,7 +58,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    seconds = 3600 * 24 * 7 # 7 days
+    duration = "168h" # 7 days
   }
 
   max_version {

--- a/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/website/docs/r/bigtable_gc_policy.html.markdown
@@ -42,7 +42,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "name"
 
   max_age {
-    days = 7
+    seconds = 3600 * 24 * 7 # 7 days
   }
 }
 ```
@@ -58,7 +58,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    days = 7
+    seconds = 3600 * 24 * 7 # 7 days
   }
 
   max_version {
@@ -89,7 +89,9 @@ The following arguments are supported:
 
 `max_age` supports the following arguments:
 
-* `days` - (Required) Number of days before applying GC policy.
+* `days` - (Deprecated) Number of days before applying GC policy.
+
+* `seconds` - (Required) Number of seconds before applying GC policy.
 
 -----
 

--- a/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/website/docs/r/bigtable_gc_policy.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `days` - (Deprecated) Number of days before applying GC policy.
 
-* `seconds` - (Required) Number of seconds before applying GC policy.
+* `duration` - (Required) Duration before applying GC policy (ex. "8h"). This is required when `days` isn't set
 
 -----
 


### PR DESCRIPTION
Allow GC policy to have a duration lower than a day, bigtable supports GC policies down to the hour. In case one day the support go to minutes/seconds the code will be already good