### PR TITLE
Add DaysSinceNoncurrentTime to the bucket life cycle rules

### DIFF
--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -182,6 +182,11 @@ func resourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Description: `Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.`,
 									},
+                                    "days_since_noncurrent_time": {
+                                        Type:        schema.TypeInt,
+                                        Optional:    true,
+                                        Description: `Relevant only for versioned objects. The number of days since the object became noncurrent, either because the live version was deleted or replaced.`,
+                                    },
 								},
 							},
 							Description: `The Lifecycle Rule's condition configuration.`,
@@ -1033,6 +1038,7 @@ func flattenBucketLifecycleRuleCondition(condition *storage.BucketLifecycleRuleC
 		"created_before":        condition.CreatedBefore,
 		"matches_storage_class": convertStringArrToInterface(condition.MatchesStorageClass),
 		"num_newer_versions":    int(condition.NumNewerVersions),
+		"days_since_noncurrent_time":    int(condition.DaysSinceNoncurrentTime),
 	}
 	if condition.IsLive == nil {
 		ruleCondition["with_state"] = "ANY"
@@ -1246,6 +1252,10 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 		transformed.NumNewerVersions = int64(v.(int))
 	}
 
+    if v, ok := condition["days_since_noncurrent_time"]; ok {
+        transformed.DaysSinceNoncurrentTime = int64(v.(int))
+    }
+
 	return transformed, nil
 }
 
@@ -1302,6 +1312,10 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 	if v, ok := m["num_newer_versions"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
+
+    if v, ok := m["days_since_noncurrent_time"]; ok {
+        buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+    }
 
 	return hashcode(buf.String())
 }

--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -182,11 +182,11 @@ func resourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Description: `Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.`,
 									},
-                                    "days_since_noncurrent_time": {
-                                        Type:        schema.TypeInt,
-                                        Optional:    true,
-                                        Description: `Relevant only for versioned objects. The number of days since the object became noncurrent, either because the live version was deleted or replaced.`,
-                                    },
+									"days_since_noncurrent_time": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `Relevant only for versioned objects. The number of days since the object became noncurrent, either because the live version was deleted or replaced.`,
+									},
 								},
 							},
 							Description: `The Lifecycle Rule's condition configuration.`,
@@ -1034,11 +1034,11 @@ func flattenBucketLifecycleRuleAction(action *storage.BucketLifecycleRuleAction)
 
 func flattenBucketLifecycleRuleCondition(condition *storage.BucketLifecycleRuleCondition) map[string]interface{} {
 	ruleCondition := map[string]interface{}{
-		"age":                   int(condition.Age),
-		"created_before":        condition.CreatedBefore,
-		"matches_storage_class": convertStringArrToInterface(condition.MatchesStorageClass),
-		"num_newer_versions":    int(condition.NumNewerVersions),
-		"days_since_noncurrent_time":    int(condition.DaysSinceNoncurrentTime),
+		"age":                        int(condition.Age),
+		"created_before":             condition.CreatedBefore,
+		"matches_storage_class":      convertStringArrToInterface(condition.MatchesStorageClass),
+		"num_newer_versions":         int(condition.NumNewerVersions),
+		"days_since_noncurrent_time": int(condition.DaysSinceNoncurrentTime),
 	}
 	if condition.IsLive == nil {
 		ruleCondition["with_state"] = "ANY"
@@ -1252,9 +1252,9 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 		transformed.NumNewerVersions = int64(v.(int))
 	}
 
-    if v, ok := condition["days_since_noncurrent_time"]; ok {
-        transformed.DaysSinceNoncurrentTime = int64(v.(int))
-    }
+	if v, ok := condition["days_since_noncurrent_time"]; ok {
+		transformed.DaysSinceNoncurrentTime = int64(v.(int))
+	}
 
 	return transformed, nil
 }
@@ -1313,9 +1313,9 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
 
-    if v, ok := m["days_since_noncurrent_time"]; ok {
-        buf.WriteString(fmt.Sprintf("%d-", v.(int)))
-    }
+	if v, ok := m["days_since_noncurrent_time"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
 
 	return hashcode(buf.String())
 }

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -1317,6 +1317,15 @@ resource "google_storage_bucket" "bucket" {
       with_state = "ARCHIVED"
     }
   }
+  lifecycle_rule {
+    action {
+      type          = "SetStorageClass"
+      storage_class = "NEARLINE"
+    }
+    condition {
+      days_since_noncurrent_time = 10
+    }
+  }
 }
 `, bucketName)
 }

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -129,6 +129,8 @@ The `condition` block supports the following elements, and requires at least one
 
 * `num_newer_versions` - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
 
+* `days_since_noncurrent_time` - (Optional) Relevant only for versioned objects. The number of days since the object became noncurrent, either because the live version was deleted or replaced.
+
 The `versioning` block supports:
 
 * `enabled` - (Required) While set to `true`, versioning is fully enabled for this bucket.


### PR DESCRIPTION
It's now possible to use DaysSinceNoncurrentTime in the bucket life cycle rules https://cloud.google.com/storage/docs/lifecycle#dayssincenoncurrenttime

> The DaysSinceNoncurrentTime condition is typically only used in conjunction with Object Versioning. The condition is satisfied when the specified number of days have passed since the object became noncurrent, either because the live version was deleted or replaced. For example, if an object became noncurrent at 2020/07/08 15:00 UTC and the DaysSinceNoncurrentTime condition is 10 days, then the condition is satisfied for the object on and after 2020/07/18 15:00 UTC.