### PR TITLE
Add support clousql mysql 8.0 for replication

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -365,7 +365,7 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 				Optional:    true,
 				Default:     "MYSQL_5_6",
 				ForceNew:    true,
-				Description: `The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, POSTGRES_9_6,POSTGRES_11, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.`,
+				Description: `The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, POSTGRES_9_6,POSTGRES_11, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.`,
 			},
 
 			"root_password": {

--- a/google/resource_sql_source_representation_instance.go
+++ b/google/resource_sql_source_representation_instance.go
@@ -47,8 +47,8 @@ func resourceSQLSourceRepresentationInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"MYSQL_5_6", "MYSQL_5_7"}, false),
-				Description:  `The MySQL version running on your source database server. Possible values: ["MYSQL_5_6", "MYSQL_5_7"]`,
+				ValidateFunc: validation.StringInSlice([]string{"MYSQL_5_6", "MYSQL_5_7", "MYSQL_8_0"}, false),
+				Description:  `The MySQL version running on your source database server. Possible values: ["MYSQL_5_6", "MYSQL_5_7", "MYSQL_8_0"]`,
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/google/resource_sql_source_representation_instance_generated_test.go
+++ b/google/resource_sql_source_representation_instance_generated_test.go
@@ -55,7 +55,7 @@ func testAccSQLSourceRepresentationInstance_sqlSourceRepresentationInstanceBasic
 resource "google_sql_source_representation_instance" "instance" {
   name             = "tf-test-my-instance%{random_suffix}"
   region           = "us-central1"
-  database_version = "MYSQL_5_7"
+  database_version = "MYSQL_8_0"
   host             = "10.20.30.40"
   port             = 3306
 }

--- a/website/docs/r/sql_source_representation_instance.html.markdown
+++ b/website/docs/r/sql_source_representation_instance.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `database_version` -
   (Required)
   The MySQL version running on your source database server.
-  Possible values are `MYSQL_5_6` and `MYSQL_5_7`.
+  Possible values are `MYSQL_5_6` and `MYSQL_5_7` and `MYSQL_8_0`.
 
 * `host` -
   (Required)


### PR DESCRIPTION
- `resource_sql_database_instance` supported mysql 8.0.
-  `resource_sql_database_instance` update description for mysql 8.0