### PR TITLE
Service account key keepers

### DIFF
--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -53,6 +53,12 @@ func resourceGoogleServiceAccountKey() *schema.Resource {
 				ConflictsWith: []string{"key_algorithm", "private_key_type"},
 				Description:   `A field that allows clients to upload their own public key. If set, use this public key data to create a service account key for given service account. Please note, the expected format for this field is a base64 encoded X509_PEM.`,
 			},
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
 			// Computed
 			"name": {
 				Type:        schema.TypeString,

--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -25,6 +25,28 @@ resource "google_service_account_key" "mykey" {
 }
 ```
 
+## Example Usage, creating and regularly rotating a key pair
+
+```hcl
+resource "google_service_account" "myaccount" {
+  account_id   = "myaccount"
+  display_name = "My Service Account"
+}
+
+# note this requires the terraform to be run regularly
+resource "time_rotating" "mykey_rotation" {
+  rotate_days = 30
+}
+
+resource "google_service_account_key" "mykey" {
+  service_account_id = google_service_account.myaccount.name
+
+  keepers = {
+    rotation_time = time_rotating.mykey_rotation.rotation_rfc3339
+  }
+}
+```
+
 ## Example Usage, save key in Kubernetes secret - DEPRECATED
 
 ```hcl
@@ -68,6 +90,8 @@ Valid values are listed at
 * `private_key_type` (Optional) The output format of the private key. TYPE_GOOGLE_CREDENTIALS_FILE is the default output format.
 
 * `public_key_data` (Optional) Public key data to create a service account key for given service account. The expected format for this field is a base64 encoded X509_PEM and it conflicts with `public_key_type` and `private_key_type`.
+
+* `keepers` (Optional) Arbitrary map of values that, when changed, will trigger a new key to be generated.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds a keepers field which permits easy rotation of service account keys, as per best practices.

Same pattern as used for [`random_*` resources](https://registry.terraform.io/providers/hashicorp/random/latest/docs#resource-keepers) and [`time_*` resources](https://registry.terraform.io/providers/hashicorp/time/latest/docs) (with `time_*`, the pattern is called "triggers").

Permits usage like the following:

```hcl
resource "time_rotating" "foo" {
    rotation_days = 7
}

resource "google_service_account_key" "foo" {
  service_account_id = google_service_account.test.name
  keepers = {
    rotation-date = time_rotating.foo.rotation_rfc3339
  }
}
```

Current alternatives are very non-obvious:
```hcl
resource "google_service_account_key" "foo" {
         service_account_id = time_rotating.foo_timer.unix > 0 ? google_service_account.foo.name : google_service_account.foo.name
}
```

Addresses this [feature request](https://github.com/hashicorp/terraform-provider-google/issues/8075).

```release-note:enhancement
serviceaccount: added a `keepers` field to `google_service_account_key` that recreates the field when it is modified
```

