### PR TITLE
Correct import directions

### DIFF
--- a/website/docs/r/kms_crypto_key.html.markdown
+++ b/website/docs/r/kms_crypto_key.html.markdown
@@ -167,9 +167,11 @@ This resource provides the following
 
 CryptoKey can be imported using any of these accepted formats:
 
+{projectId}/{locationId}/{KeyringName}/{cryptoKeyName}`
+
 ```
-$ terraform import google_kms_crypto_key.default {{key_ring}}/cryptoKeys/{{name}}
-$ terraform import google_kms_crypto_key.default {{key_ring}}/{{name}}
+$ terraform import google_kms_crypto_key.default {{project}}/{{location}}/{{key_ring}}/{{name}}
+$ terraform import google_kms_crypto_key.default {{location}}/{{key_ring}}/{{name}}
 ```
 
 ## User Project Overrides

--- a/website/docs/r/kms_crypto_key.html.markdown
+++ b/website/docs/r/kms_crypto_key.html.markdown
@@ -167,8 +167,6 @@ This resource provides the following
 
 CryptoKey can be imported using any of these accepted formats:
 
-{projectId}/{locationId}/{KeyringName}/{cryptoKeyName}`
-
 ```
 $ terraform import google_kms_crypto_key.default {{project}}/{{location}}/{{key_ring}}/{{name}}
 $ terraform import google_kms_crypto_key.default {{location}}/{{key_ring}}/{{name}}


### PR DESCRIPTION
I believe that the documentation might be incorrect, or the behavior of the API changed. It appears that `location` must be provided. I tried to import with `terraform import google_kms_crypto_key.worker_auth asgard-boundary/worker-auth` and encountered the error:

```
Error: Invalid CryptoKey id format, expecting `{projectId}/{locationId}/{KeyringName}/{cryptoKeyName}` or `{locationId}/{keyRingName}/{cryptoKeyName}, got id: asgard-boundary/worker-auth`
```

By prepending `location` according to the directions from the error, I achieved the desired import.