### PR TITLE
Fix typo: GCP authentication environment variable in document

### DIFF
--- a/website/docs/guides/provider_reference.html.markdown
+++ b/website/docs/guides/provider_reference.html.markdown
@@ -77,7 +77,7 @@ credential/authentication file. Make sure that the scope of the VM/Cluster is se
 
 ### Running Terraform outside of Google Cloud
 
-If you are running terraform outside of Google Cloud, generate a service account key and set the `GOOGLE_APPPLICATION_CREDENTIALS` environment variable to
+If you are running terraform outside of Google Cloud, generate a service account key and set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to
 the path of the service account key. Terraform will use that key for authentication.
 
 ### Impersonating Service Accounts


### PR DESCRIPTION
Hi I just started using GCP provider and I found typo in `website/docs/guides/provider_reference.html.markdown`.

I checked official document (https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable) and `GOOGLE_APPLICATION_CREDENTIALS` (not GOOGLE_APP**P**LICATION_CREDENTIALS) is correct (and other files in `website/docs` are fine. ).

Could you check this? This might be helpful for beginners.