### PR TITLE
Use connection_name in Cloud Run Sql example

### DIFF
--- a/website/docs/r/cloud_run_service.html.markdown
+++ b/website/docs/r/cloud_run_service.html.markdown
@@ -94,7 +94,7 @@ resource "google_cloud_run_service" "default" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale"      = "1000"
-        "run.googleapis.com/cloudsql-instances" = "my-project-name:us-central1:${google_sql_database_instance.instance.name}"
+        "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.instance.connection_name
         "run.googleapis.com/client-name"        = "terraform"
       }
     }


### PR DESCRIPTION
It gives the same result as the previous string, but is more robust because the project ID and the instance region are not hardcoded.

```release-note:none

```