### PR TITLE
Add `temp_bucket` parameter for resource google_dataproc_cluster (fixes #7927)

### DIFF
--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -165,7 +165,7 @@ func resourceDataprocCluster() *schema.Resource {
 							Computed:     true,
 							AtLeastOneOf: clusterConfigKeys,
 							ForceNew:     true,
-							Description:  `The Cloud Storage temp bucket used to store ephemeral cluster and jobs data, such as Spark and MapReduce history files.. Note: If you don't explicitly specify a temp_bucket then GCP will auto create / assign one for you.`,
+							Description:  `The Cloud Storage temp bucket used to store ephemeral cluster and jobs data, such as Spark and MapReduce history files. Note: If you don't explicitly specify a temp_bucket then GCP will auto create / assign one for you.`,
 						},
 
 						"gce_cluster_config": {

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -43,6 +43,7 @@ var (
 
 	clusterConfigKeys = []string{
 		"cluster_config.0.staging_bucket",
+		"cluster_config.0.temp_bucket",
 		"cluster_config.0.gce_cluster_config",
 		"cluster_config.0.master_config",
 		"cluster_config.0.worker_config",
@@ -156,6 +157,14 @@ func resourceDataprocCluster() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: ` The name of the cloud storage bucket ultimately used to house the staging data for the cluster. If staging_bucket is specified, it will contain this value, otherwise it will be the auto generated name.`,
+						},
+
+						"temp_bucket": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: clusterConfigKeys,
+							ForceNew:     true,
+							Description:  `The Cloud Storage temp bucket used to store ephemeral cluster and jobs data, such as Spark and MapReduce history files.. Note: If you don't explicitly specify a temp_bucket then GCP will auto create / assign one for you.`,
 						},
 
 						"gce_cluster_config": {
@@ -779,6 +788,10 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 		conf.ConfigBucket = v.(string)
 	}
 
+	if v, ok := d.GetOk("cluster_config.0.temp_bucket"); ok {
+		conf.TempBucket = v.(string)
+	}
+
 	c, err := expandGceClusterConfig(d, config)
 	if err != nil {
 		return nil, err
@@ -1208,6 +1221,7 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		"staging_bucket": d.Get("cluster_config.0.staging_bucket").(string),
 
 		"bucket":                    cfg.ConfigBucket,
+		"temp_bucket":               cfg.TempBucket,
 		"gce_cluster_config":        flattenGceClusterConfig(d, cfg.GceClusterConfig),
 		"security_config":           flattenSecurityConfig(d, cfg.SecurityConfig),
 		"software_config":           flattenSoftwareConfig(d, cfg.SoftwareConfig),

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -162,6 +162,7 @@ func resourceDataprocCluster() *schema.Resource {
 						"temp_bucket": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							AtLeastOneOf: clusterConfigKeys,
 							ForceNew:     true,
 							Description:  `The Cloud Storage temp bucket used to store ephemeral cluster and jobs data, such as Spark and MapReduce history files.. Note: If you don't explicitly specify a temp_bucket then GCP will auto create / assign one for you.`,

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -171,6 +171,10 @@ The `cluster_config` block supports:
    with other clusters in the same region/zone also choosing to use the auto generation
    option.
 
+* `temp_bucket` - (Optional) The Cloud Storage temp bucket used to store ephemeral cluster
+   and jobs data, such as Spark and MapReduce history files.
+   Note: If you don't explicitly specify a `temp_bucket` then GCP will auto create / assign one for you.
+
 * `gce_cluster_config` (Optional) Common config settings for resources of Google Compute Engine cluster
    instances, applicable to all instances in the cluster. Structure defined below.
 


### PR DESCRIPTION
Allow using `temp_bucket` when creating a Dataproc cluster as addressed in #7927 .

Closes #7927 .

If this PR is for Terraform, I acknowledge that I have:
* [x]  Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
* [x]  [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
* [x]  Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
* [x]  [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
* [x]  Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataproc: Added field `temp_bucket` to `google_dataproc_cluster` cluster config.
```