### PR TITLE
Add support for configuring disk resource policies for google_compute_instance_template.

### DIFF
--- a/google/resource_compute_instance_template.go
+++ b/google/resource_compute_instance_template.go
@@ -214,7 +214,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							MaxItems:    1,
-							Description: `A list of short names or self_links of resource policies to attach to this disk. Currently a max of 1 resource policy is supported.`,
+							Description: `A list (short name or id) of resource policies to attach to this disk. Currently a max of 1 resource policy is supported.`,
 							Elem: &schema.Schema{
 								Type:             schema.TypeString,
 								DiffSuppressFunc: compareResourceNames,

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -2278,7 +2278,7 @@ resource "google_compute_instance_template" "foobar" {
 
   disk {
     source_image = data.google_compute_image.my_image.self_link
-    resource_policies = [google_compute_resource_policy.foo.self_link]
+    resource_policies = [google_compute_resource_policy.foo.id]
   }
 
   network_interface {

--- a/google/resource_compute_instance_template_test.go
+++ b/google/resource_compute_instance_template_test.go
@@ -898,6 +898,33 @@ func TestAccComputeInstanceTemplate_imageResourceTest(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_resourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate computeBeta.InstanceTemplate
+	policyName := "tf-test-policy-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_resourcePolicies(randString(t, 10), policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateHasDiskResourcePolicy(&instanceTemplate, policyName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -1241,6 +1268,17 @@ func testAccCheckComputeInstanceTemplateLacksShieldedVmConfig(instanceTemplate *
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.ShieldedVmConfig != nil {
 			return fmt.Errorf("Expected no shielded vm config")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceTemplateHasDiskResourcePolicy(instanceTemplate *computeBeta.InstanceTemplate, resourcePolicy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourcePolicyActual := instanceTemplate.Properties.Disks[0].InitializeParams.ResourcePolicies[0]
+		if resourcePolicyActual != resourcePolicy {
+			return fmt.Errorf("Wrong disk resource policy: expected %s, got %s", resourcePolicy, resourcePolicyActual)
 		}
 
 		return nil
@@ -2200,7 +2238,7 @@ data "google_compute_image" "my_image" {
 	family  = "debian-9"
 	project = "debian-cloud"
 }
-	
+
 resource "google_compute_disk" "my_disk" {
 	name  = "%s"
 	zone  = "us-central1-a"
@@ -2222,6 +2260,51 @@ resource "google_compute_instance_template" "foobar" {
 		access_config {}
 	}
 }
-	  
+
 `, diskName, imageName, imageDescription)
+}
+
+func testAccComputeInstanceTemplate_resourcePolicies(suffix string, policyName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "instance-test-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    resource_policies = [google_compute_resource_policy.foo.self_link]
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+
+resource "google_compute_resource_policy" "foo" {
+  name   = "%s"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "04:00"
+      }
+    }
+  }
+}
+`, suffix, policyName)
 }

--- a/website/docs/d/compute_instance_template.html.markdown
+++ b/website/docs/d/compute_instance_template.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 - `name` - (Optional) The name of the instance template. One of `name` or `filter` must be provided.
 
-- `filter` - (Optional) A filter to retrieve the instance templates. 
+- `filter` - (Optional) A filter to retrieve the instance templates.
     See [gcloud topic filters](https://cloud.google.com/sdk/gcloud/reference/topic/filters) for reference.
     If multiple instance templates match, either adjust the filter or specify `most_recent`. One of `name` or `filter` must be provided.
 
@@ -137,9 +137,9 @@ The `disk` block supports:
     `{project}/{image}`, `{family}`, or `{image}`.
 ~> **Note:** Either `source` or `source_image` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
 
-* `interface` - Specifies the disk interface to use for attaching this disk, 
-    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI 
-    and the request will fail if you attempt to attach a persistent disk in any other format 
+* `interface` - Specifies the disk interface to use for attaching this disk,
+    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI
+    and the request will fail if you attempt to attach a persistent disk in any other format
     than SCSI. Local SSDs can use either NVME or SCSI.
 
 * `mode` - The mode in which to attach this disk, either READ_WRITE
@@ -169,6 +169,8 @@ The `disk` block supports:
     If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
 
     Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
+
+* `resource_policies` (Optional) -- A list of short names of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
 
 The `disk_encryption_key` block supports:
 

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -48,7 +48,7 @@ resource "google_compute_instance_template" "default" {
     auto_delete       = true
     boot              = true
     // backup the disk every day
-    resource_policies = [google_compute_resource_policy.daily_backup.name]
+    resource_policies = [google_compute_resource_policy.daily_backup.id]
   }
 
   // Use an existing disk resource
@@ -326,7 +326,7 @@ The `disk` block supports:
 
     Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
 
-* `resource_policies` (Optional) -- A list of short names or self_links of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
+* `resource_policies` (Optional) -- A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
 
 The `disk_encryption_key` block supports:
 

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -44,9 +44,11 @@ resource "google_compute_instance_template" "default" {
 
   // Create a new boot disk from an image
   disk {
-    source_image = "debian-cloud/debian-9"
-    auto_delete  = true
-    boot         = true
+    source_image      = "debian-cloud/debian-9"
+    auto_delete       = true
+    boot              = true
+    // backup the disk every day
+    resource_policies = [google_compute_resource_policy.daily_backup.name]
   }
 
   // Use an existing disk resource
@@ -83,6 +85,19 @@ resource "google_compute_disk" "foobar" {
   size  = 10
   type  = "pd-ssd"
   zone  = "us-central1-a"
+}
+
+resource "google_compute_resource_policy" "daily_backup" {
+  name   = "every-day-4am"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "04:00"
+      }
+    }
+  }
 }
 ```
 
@@ -278,9 +293,9 @@ The `disk` block supports:
     `{project}/{image}`, `{family}`, or `{image}`.
 ~> **Note:** Either `source` or `source_image` is **required** in a disk block unless the disk type is `local-ssd`. Check the API [docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates/insert) for details.
 
-* `interface` - (Optional) Specifies the disk interface to use for attaching this disk, 
-    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI 
-    and the request will fail if you attempt to attach a persistent disk in any other format 
+* `interface` - (Optional) Specifies the disk interface to use for attaching this disk,
+    which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI
+    and the request will fail if you attempt to attach a persistent disk in any other format
     than SCSI. Local SSDs can use either NVME or SCSI.
 
 * `mode` - (Optional) The mode in which to attach this disk, either READ_WRITE
@@ -310,6 +325,8 @@ The `disk` block supports:
     If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
 
     Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
+
+* `resource_policies` (Optional) -- A list of short names or self_links of resource policies to attach to this disk for automatic snapshot creations. Currently a max of 1 resource policy is supported.
 
 The `disk_encryption_key` block supports:
 


### PR DESCRIPTION
Fixes #6719

Per documentation (and checked), https://pkg.go.dev/google.golang.org/api/compute/v0.beta#AttachedDiskInitializeParams only the resource policy _name_ is supported for instance templates, a uri can't be used. A link can be used in user code, but it will be converted to the resource name.