### PR TITLE
docs: fix incorrect argument name in time_rotating example

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -35,7 +35,7 @@ resource "google_service_account" "myaccount" {
 
 # note this requires the terraform to be run regularly
 resource "time_rotating" "mykey_rotation" {
-  rotate_days = 30
+  rotation_days = 30
 }
 
 resource "google_service_account_key" "mykey" {


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating#argument-reference

fixes an error when using the documented example:

```
Error: Unsupported argument

  on main.tf line 17, in resource "time_rotating" "rotation":
  17:   rotate_days = 30

An argument named "rotate_days" is not expected here.
```