### PR TITLE
Update required role bindings on KMS key

### DIFF
--- a/website/docs/r/privateca_certificate_authority.html.markdown
+++ b/website/docs/r/privateca_certificate_authority.html.markdown
@@ -134,10 +134,20 @@ resource "google_project_service_identity" "privateca_sa" {
   service  = "privateca.googleapis.com"
 }
 
-resource "google_kms_crypto_key_iam_binding" "privateca_sa_keyuser" {
+resource "google_kms_crypto_key_iam_binding" "privateca_sa_keyuser_signerverifier" {
   provider      = google-beta
   crypto_key_id = "projects/keys-project/locations/us-central1/keyRings/key-ring/cryptoKeys/crypto-key"
   role          = "roles/cloudkms.signerVerifier"
+
+  members = [
+    "serviceAccount:${google_project_service_identity.privateca_sa.email}",
+  ]
+}
+
+resource "google_kms_crypto_key_iam_binding" "privateca_sa_keyuser_viewer" {
+  provider      = google-beta
+  crypto_key_id = "projects/keys-project/locations/us-central1/keyRings/key-ring/cryptoKeys/crypto-key"
+  role          = "roles/viewer"
 
   members = [
     "serviceAccount:${google_project_service_identity.privateca_sa.email}",


### PR DESCRIPTION
Per the [official docs](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles#service_agent), the CAS service agent needs two role bindings on a CMEK. The current doc only includes one of these (`roles/cloudkms.signerVerifier`), so this change just adds the second one (`roles/viewer`).