### PR TITLE
Fix time_rotating argument name

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -35,7 +35,7 @@ resource "google_service_account" "myaccount" {
 
 # note this requires the terraform to be run regularly
 resource "time_rotating" "mykey_rotation" {
-  rotate_days = 30
+  rotation_days = 30
 }
 
 resource "google_service_account_key" "mykey" {


### PR DESCRIPTION
One of the example definitions shows `rotate_days` as argument of `time_rotating` resource.

This argument should be called `rotation_days`, as defined at the current [resource documentation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating#rotation_days) (as of today using version `0.6.0`).