### PR TITLE
data.google_compute_network: subnetworks_self_links to set

### DIFF
--- a/google/data_source_google_compute_network.go
+++ b/google/data_source_google_compute_network.go
@@ -37,7 +37,7 @@ func dataSourceGoogleComputeNetwork() *schema.Resource {
 			},
 
 			"subnetworks_self_links": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/website/docs/d/compute_network.html.markdown
+++ b/website/docs/d/compute_network.html.markdown
@@ -39,6 +39,6 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `gateway_ipv4` - The IP address of the gateway.
 
-* `subnetworks_self_links` - the list of subnetworks which belong to the network
+* `subnetworks_self_links` - the set of subnetworks which belong to the network
 
 * `self_link` - The URI of the resource.


### PR DESCRIPTION
since all `subnetworks_self_links` should be unique, shouldn't this be a `set` instead of a `list`?

would allow looping through these outputs without conversion