### PR TITLE
Corrected version.ProviderVersion path (1/2)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ test: fmtcheck generate
 	go test $(TESTARGS) -timeout=30s $(TEST)
 
 testacc: fmtcheck generate
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
+	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/v3/version.ProviderVersion=acc"
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."


### PR DESCRIPTION
This change makes tests run with `make testacc` correctly set the provider version to "acc" instead of "dev". The path changed because of https://github.com/hashicorp/terraform-provider-google/pull/7982.

Part 2: https://github.com/hashicorp/terraform-provider-google-beta/pull/2934

b/179263738