### PR TITLE
Update documentation for sql instance

### DIFF
--- a/website/docs/d/sql_database_instance.html.markdown
+++ b/website/docs/d/sql_database_instance.html.markdown
@@ -53,7 +53,7 @@ The `settings` block contains:
 * `tier` - The machine type to use.
     
 * `activation_policy` - This specifies when the instance should be
-    active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
+    active. Can be either `ALWAYS` or `NEVER`.
 
 * `authorized_gae_applications` - (Deprecated) This property is only applicable to First Generation instances.
     First Generation instances are now deprecated, see [here](https://cloud.google.com/sql/docs/mysql/upgrade-2nd-gen)

--- a/website/docs/d/sql_database_instance.html.markdown
+++ b/website/docs/d/sql_database_instance.html.markdown
@@ -53,7 +53,7 @@ The `settings` block contains:
 * `tier` - The machine type to use.
     
 * `activation_policy` - This specifies when the instance should be
-    active. Can be either `ALWAYS` or `NEVER`.
+    active. Can be either `ALWAYS` or `NEVER`. Additionnally, the option `ON_DEMAND` is available only for first-generation instances.
 
 * `authorized_gae_applications` - (Deprecated) This property is only applicable to First Generation instances.
     First Generation instances are now deprecated, see [here](https://cloud.google.com/sql/docs/mysql/upgrade-2nd-gen)

--- a/website/docs/d/sql_database_instance.html.markdown
+++ b/website/docs/d/sql_database_instance.html.markdown
@@ -53,7 +53,7 @@ The `settings` block contains:
 * `tier` - The machine type to use.
     
 * `activation_policy` - This specifies when the instance should be
-    active. Can be either `ALWAYS` or `NEVER`. Additionnally, the option `ON_DEMAND` is available only for first-generation instances.
+    active. Can be either `ALWAYS` or `NEVER`.
 
 * `authorized_gae_applications` - (Deprecated) This property is only applicable to First Generation instances.
     First Generation instances are now deprecated, see [here](https://cloud.google.com/sql/docs/mysql/upgrade-2nd-gen)


### PR DESCRIPTION
This is a PR to update the documentation.
By using the ON_DEMAND option, I had this error:
`Error: Error, failed to update instance settings for : googleapi: Error 400: Invalid request: Invalid flag for instance role: GCE instances do not support 'ON_DEMAND' activation policy.., invalid`

Based on this document (https://cloud.google.com/sql/docs/mysql/start-stop-restart-instance), it looks like the option ON_DEMAND is not an available.

Addendum: the option is not available for second-generation instances.
Error via gcloud:
`(gcloud.sql.instances.patch) HTTPError 400: Invalid request: 2nd Gen instance can't set ON_DEMAND activation policy.`

```release-note:none

```
