### PR TITLE
Update dns_record_set.html.markdown

### DIFF
--- a/website/docs/r/dns_record_set.html.markdown
+++ b/website/docs/r/dns_record_set.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 * `name` - (Required) The DNS name this record set will apply to.
 
 * `rrdatas` - (Required) The string data for the records in this record set
-    whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding `\"` if you don't want your string to get split on spaces. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the Terraform configuration string (e.g. `"first255characters\"\"morecharacters"`).
+    whose meaning depends on the DNS type. For TXT record, if the string data contains spaces, add surrounding `\"` if you don't want your string to get split on spaces. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\" \"` inside the Terraform configuration string (e.g. `"first255characters\" \"morecharacters"`).
 
 * `ttl` - (Required) The time-to-live of this record set (seconds).
 


### PR DESCRIPTION
If you don't add this space, your plans will always see a space between the records on the remote side of things, and will always have a non-empty plan for such records.

```release-note:none

```