### PR TITLE
Fixes typo in example

### DIFF
--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -54,7 +54,7 @@ resource "google_sql_database_instance" "master" {
   settings {
     tier = "db-f1-micro"
 
-    datagbase_flags {
+    database_flags {
       name  = "cloudsql.iam_authentication"
       value = "on"
     }


### PR DESCRIPTION
Fixes a small typo in the database_flags part of this example.