### PR TITLE
Stopped marking provider as a /v3 library (1/2)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ test: fmtcheck generate
 	go test $(TESTARGS) -timeout=30s $(TEST)
 
 testacc: fmtcheck generate
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/v3/version.ProviderVersion=acc"
+	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/terraform-provider-google/v3
+module github.com/hashicorp/terraform-provider-google
 
 require (
 	cloud.google.com/go/bigtable v1.5.0

--- a/google/provider.go
+++ b/google/provider.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-google/v3/version"
+	"github.com/hashicorp/terraform-provider-google/version"
 
 	googleoauth "golang.org/x/oauth2/google"
 )

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/hashicorp/terraform-provider-google/v3/google"
+	"github.com/hashicorp/terraform-provider-google/google"
 )
 
 func main() {


### PR DESCRIPTION
This follows guidance from hashicorp to not import providers as go modules. See https://www.terraform.io/docs/extend/best-practices/depending-on-providers.html for more details.

We originally added /v3 as part of upgrading terraform-validator to the latest versions of the terraform provider; this inadvertently broke proper setting of the release version in the release pipeline. See b/179263738 for details.