### PR TITLE
website/spanner_instance: Fixed the documentation

### DIFF
--- a/website/docs/d/spanner_instance.html.markdown
+++ b/website/docs/d/spanner_instance.html.markdown
@@ -1,13 +1,13 @@
 ---
 subcategory: "Cloud Spanner"
 layout: "google"
-page_title: "Google: google_compute_global_forwarding_rule"
+page_title: "Google: google_spanner_instance"
 sidebar_current: "docs-google-datasource-spanner-instance"
 description: |-
   Get a spanner instance from Google Cloud
 ---
 
-# google\_compute\_global_\forwarding\_rule
+# google\_spanner\_instance
 
 Get a spanner instance from Google Cloud by its name.
 

--- a/website/google.erb
+++ b/website/google.erb
@@ -1371,7 +1371,7 @@
         <ul class="nav nav-auto-expand">
     
           <li>
-          <a href="/docs/providers/google/d/spanner_instance.html">google_compute_global_forwarding_rule</a>
+          <a href="/docs/providers/google/d/spanner_instance.html">google_spanner_instance</a>
           </li>
     
         </ul>


### PR DESCRIPTION
Run the `make build` to generate the docs.