### PR TITLE
Update google_sql_database_instance documentation

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -217,7 +217,7 @@ includes an up-to-date reference of supported versions.
     is not provided, the provider project is used.
 
 * `replica_configuration` - (Optional) The configuration for replication. The
-    configuration is detailed below.
+    configuration is detailed below. Valid only for MySQL instances.
     
 * `root_password` - (Optional) Initial root password. Required for MS SQL Server, ignored by MySQL and PostgreSQL.
 


### PR DESCRIPTION
The `replica_configuration` block is used to configure external replication, which is not currently supported for PostgreSQL instances, nor for MS SQL instances.

See:
- https://cloud.google.com/sql/docs/mysql/replication/configure-external-replica
- https://cloud.google.com/sql/docs/mysql/replication