### PR TITLE
Allow MYSQL_5_5 for database_version

### DIFF
--- a/google/resource_sql_source_representation_instance.go
+++ b/google/resource_sql_source_representation_instance.go
@@ -47,8 +47,8 @@ func resourceSQLSourceRepresentationInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"MYSQL_5_6", "MYSQL_5_7", "MYSQL_8_0"}, false),
-				Description:  `The MySQL version running on your source database server. Possible values: ["MYSQL_5_6", "MYSQL_5_7", "MYSQL_8_0"]`,
+				ValidateFunc: validation.StringInSlice([]string{"MYSQL_5_5", "MYSQL_5_6", "MYSQL_5_7", "MYSQL_8_0"}, false),
+				Description:  `The MySQL version running on your source database server. Possible values: ["MYSQL_5_5", "MYSQL_5_6", "MYSQL_5_7", "MYSQL_8_0"]`,
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/website/docs/r/sql_source_representation_instance.html.markdown
+++ b/website/docs/r/sql_source_representation_instance.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `database_version` -
   (Required)
   The MySQL version running on your source database server.
-  Possible values are `MYSQL_5_6`, `MYSQL_5_7`, and `MYSQL_8_0`.
+  Possible values are `MYSQL_5_5`, `MYSQL_5_6`, `MYSQL_5_7`, and `MYSQL_8_0`.
 
 * `host` -
   (Required)

--- a/website/docs/r/sql_source_representation_instance.html.markdown
+++ b/website/docs/r/sql_source_representation_instance.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `database_version` -
   (Required)
   The MySQL version running on your source database server.
-  Possible values are `MYSQL_5_5`, `MYSQL_5_6`, `MYSQL_5_7`, and `MYSQL_8_0`.
+  Possible values include the following `MYSQL_5_5`, `MYSQL_5_6`, `MYSQL_5_7`, and `MYSQL_8_0`.
 
 * `host` -
   (Required)


### PR DESCRIPTION
Per the [GCP documentation](https://cloud.google.com/sql/docs/mysql/replication/replication-from-external#setup-source-instance), MYSQL_5_5 is a valid value for source representation instance. As such, terraform-provider-google should support this as well. 

This is particularly useful when migrating from a legacy instance (hosted elsewhere) to a Cloud SQL instance of a newer version.