### PR TITLE
Add require_partition_filter to BigQuery table with hive_partitioning

### DIFF
--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -1426,7 +1426,7 @@ func flattenHivePartitioningOptions(opts *bigquery.HivePartitioningOptions) []ma
 	}
 
 	if opts.RequirePartitionFilter {
-		result["require_partition_filter"] = tp.RequirePartitionFilter
+		result["require_partition_filter"] = opts.RequirePartitionFilter
 	}
 
 	if opts.SourceUriPrefix != "" {

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -522,6 +522,14 @@ func resourceBigQueryTable() *schema.Resource {
 										Optional:    true,
 										Description: `When set, what mode of hive partitioning to use when reading data.`,
 									},
+									// RequirePartitionFilter: [Optional] If set to true, queries over this table
+									// require a partition filter that can be used for partition elimination to be
+									// specified.
+									"require_partition_filter": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.`,
+									},
 									// SourceUriPrefix: [Optional] [Experimental] When hive partition detection is requested, a common for all source uris must be required.
 									// The prefix must end immediately before the partition key encoding begins.
 									"source_uri_prefix": {
@@ -1399,6 +1407,10 @@ func expandHivePartitioningOptions(configured interface{}) *bigquery.HivePartiti
 		opts.Mode = v.(string)
 	}
 
+	if v, ok := raw["require_partition_filter"]; ok {
+		opts.RequirePartitionFilter = v.(bool)
+	}
+
 	if v, ok := raw["source_uri_prefix"]; ok {
 		opts.SourceUriPrefix = v.(string)
 	}
@@ -1411,6 +1423,10 @@ func flattenHivePartitioningOptions(opts *bigquery.HivePartitioningOptions) []ma
 
 	if opts.Mode != "" {
 		result["mode"] = opts.Mode
+	}
+
+	if opts.RequirePartitionFilter {
+		result["require_partition_filter"] = tp.RequirePartitionFilter
 	}
 
 	if opts.SourceUriPrefix != "" {

--- a/google/resource_bigquery_table_test.go
+++ b/google/resource_bigquery_table_test.go
@@ -973,6 +973,7 @@ resource "google_bigquery_table" "test" {
     hive_partitioning_options {
       mode = "AUTO"
       source_uri_prefix = "gs://${google_storage_bucket.test.name}/"
+	  require_partition_filter = true
     }
 
   }
@@ -1011,6 +1012,7 @@ resource "google_bigquery_table" "test" {
     hive_partitioning_options {
       mode = "CUSTOM"
       source_uri_prefix = "gs://${google_storage_bucket.test.name}/{key1:STRING}"
+	  require_partition_filter = true
     }
 
     schema = <<EOH

--- a/website/docs/r/bigquery_table.html.markdown
+++ b/website/docs/r/bigquery_table.html.markdown
@@ -240,6 +240,10 @@ The `hive_partitioning_options` block supports:
       partitioning on an unsupported format will lead to an error.
       Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.
     * CUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`.
+    
+* `require_partition_filter` - (Optional) If set to true, queries over this table
+    require a partition filter that can be used for partition elimination to be
+    specified.
 
 * `source_uri_prefix` (Optional) - When hive partition detection is requested,
     a common for all source uris must be required. The prefix must end immediately


### PR DESCRIPTION
With the `google.golang.org/api v0.41.0` (version already in use) we have access to define the `require_partition_filter` for External BQ tables with `hive_partitioning` ([Reference](https://github.com/googleapis/google-api-go-client/blob/v0.41.0/bigquery/v2/bigquery-gen.go#L3201))

In this [PR](https://github.com/hashicorp/terraform-provider-google/pull/6488), it was added the functionality to have BQ tables with hive_partitioning, but it wasn't possible to add the `require_partition_filter`.