### PR TITLE
Add E2_HIGHCPU_8 and E2_HIGHCPU_32 MachineType validations

### DIFF
--- a/google/resource_cloud_build_trigger.go
+++ b/google/resource_cloud_build_trigger.go
@@ -392,8 +392,8 @@ The elements are of the form "KEY=VALUE" for the environment variable "KEY" bein
 									"machine_type": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", ""}, false),
-										Description:  `Compute Engine machine type on which to run the build. Possible values: ["UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32"]`,
+										ValidateFunc: validation.StringInSlice([]string{"UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32", ""}, false),
+										Description:  `Compute Engine machine type on which to run the build. Possible values: ["UNSPECIFIED", "N1_HIGHCPU_8", "N1_HIGHCPU_32", "E2_HIGHCPU_8", "E2_HIGHCPU_32"]`,
 									},
 									"requested_verify_option": {
 										Type:         schema.TypeString,

--- a/website/docs/r/cloudbuild_trigger.html.markdown
+++ b/website/docs/r/cloudbuild_trigger.html.markdown
@@ -612,7 +612,7 @@ The `options` block supports:
 * `machine_type` -
   (Optional)
   Compute Engine machine type on which to run the build.
-  Possible values are `UNSPECIFIED`, `N1_HIGHCPU_8`, and `N1_HIGHCPU_32`.
+  Possible values are `UNSPECIFIED`, `N1_HIGHCPU_8`, `N1_HIGHCPU_32`, `E2_HIGHCPU_8`, and `E2_HIGHCPU_32`.
 
 * `disk_size_gb` -
   (Optional)


### PR DESCRIPTION
New machine types supported by Cloud Build. Ref: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype