### PR TITLE
Add `path` on GCS targets in `google_storage_transfer_job`

### DIFF
--- a/google/resource_storage_transfer_job.go
+++ b/google/resource_storage_transfer_job.go
@@ -320,6 +320,13 @@ func gcsDataSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: `Google Cloud Storage bucket name.`,
 			},
+			"path": {
+				Optional:     true,
+				Type:         schema.TypeString,
+				Description:  `Google Cloud Storage path in bucket to transfer`,
+				Default:      "",
+				ValidateFunc: validateRegexp("^[^/].*/$"),
+			},
 		},
 	}
 }
@@ -697,12 +704,14 @@ func expandGcsData(gcsDatas []interface{}) *storagetransfer.GcsData {
 	gcsData := gcsDatas[0].(map[string]interface{})
 	return &storagetransfer.GcsData{
 		BucketName: gcsData["bucket_name"].(string),
+		Path:       gcsData["path"].(string),
 	}
 }
 
 func flattenGcsData(gcsData *storagetransfer.GcsData) []map[string]interface{} {
 	data := map[string]interface{}{
 		"bucket_name": gcsData.BucketName,
+		"path":        gcsData.Path,
 	}
 
 	return []map[string]interface{}{data}

--- a/google/resource_storage_transfer_job.go
+++ b/google/resource_storage_transfer_job.go
@@ -322,9 +322,9 @@ func gcsDataSchema() *schema.Resource {
 			},
 			"path": {
 				Optional:     true,
+				Computed:     true,
 				Type:         schema.TypeString,
 				Description:  `Google Cloud Storage path in bucket to transfer`,
-				Default:      "",
 				ValidateFunc: validateRegexp("^[^/].*/$"),
 			},
 		},
@@ -702,10 +702,17 @@ func expandGcsData(gcsDatas []interface{}) *storagetransfer.GcsData {
 	}
 
 	gcsData := gcsDatas[0].(map[string]interface{})
-	return &storagetransfer.GcsData{
+
+	var apiData = &storagetransfer.GcsData{
 		BucketName: gcsData["bucket_name"].(string),
-		Path:       gcsData["path"].(string),
 	}
+	var path = gcsData["path"].(string)
+
+	if len(path) != 0 {
+		apiData.Path = path
+	}
+
+	return apiData
 }
 
 func flattenGcsData(gcsData *storagetransfer.GcsData) []map[string]interface{} {

--- a/google/resource_storage_transfer_job_test.go
+++ b/google/resource_storage_transfer_job_test.go
@@ -153,9 +153,11 @@ resource "google_storage_transfer_job" "transfer_job" {
   transfer_spec {
     gcs_data_source {
       bucket_name = google_storage_bucket.data_source.name
+      path  = "foo/bar/"
     }
     gcs_data_sink {
       bucket_name = google_storage_bucket.data_sink.name
+      path = "fizz/buzz/"
     }
   }
 

--- a/website/docs/r/storage_transfer_job.html.markdown
+++ b/website/docs/r/storage_transfer_job.html.markdown
@@ -151,10 +151,12 @@ The `transfer_options` block supports:
 The `gcs_data_sink` block supports:
 
 * `bucket_name` - (Required) Google Cloud Storage bucket name.
+* `path` - (Optional) Root path to transfer objects. Must be an empty string or full path name that ends with a '/'. This field is treated as an object prefix. As such, it should generally not begin with a '/'. 
 
 The `gcs_data_source` block supports:
 
 * `bucket_name` - (Required) Google Cloud Storage bucket name.
+* `path` - (Optional) Root path to transfer objects. Must be an empty string or full path name that ends with a '/'. This field is treated as an object prefix. As such, it should generally not begin with a '/'.
 
 The `aws_s3_data_source` block supports:
 


### PR DESCRIPTION
Fix #8704 

It is my first contribution and i am little concern about style in documentation. It was copied out form REST api docs, but could be little confusing on usage. What do you think ?