### PR TITLE
Adds labels to disk on instance templates

### DIFF
--- a/website/docs/d/compute_instance_template.html.markdown
+++ b/website/docs/d/compute_instance_template.html.markdown
@@ -157,6 +157,9 @@ The `disk` block supports:
     specified, it will inherit the size of its base image. For SCRATCH disks,
     the size must be exactly 375GB.
 
+* `labels` - (Optional) A set of ket/value label pairs to assign to disk created from
+    this template
+
 * `type` - The type of GCE disk, can be either `"SCRATCH"` or
     `"PERSISTENT"`.
 

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -313,6 +313,9 @@ The `disk` block supports:
     specified, it will inherit the size of its base image. For SCRATCH disks,
     the size must be exactly 375GB.
 
+* `labels` - (Optional) A set of ket/value label pairs to assign to disk created from
+    this template
+
 * `type` - (Optional) The type of GCE disk, can be either `"SCRATCH"` or
     `"PERSISTENT"`.
 


### PR DESCRIPTION
Created to address #9051 

In an old issue #2026 labels was added to disk on an instance template. 

```release-note:none

```