### PR TITLE
add details to google_service_account_key documentation

### DIFF
--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -21,7 +21,7 @@ func resourceGoogleServiceAccountKey() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `The ID of the parent service account of the key. This can be a string in the format {ACCOUNT} or projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}, where {ACCOUNT} is the email address or unique id of the service account. If the {ACCOUNT} syntax is used, the project will be inferred from the account.`,
+				Description: `The ID of the parent service account of the key. This can be a string in the format {ACCOUNT} or projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}, where {ACCOUNT} is the email address or unique id of the service account. If the {ACCOUNT} syntax is used, the project will be inferred from the provider's configuration.`,
 			},
 			// Optional
 			"key_algorithm": {


### PR DESCRIPTION
I do think this is actually important because if you use `account_id` to reference the account and the provider has no specified project, `terraform plan` will return no error while `terraform apply` will complain about a missing `project` field.

The issue is that, this pass the **plan** but not the **apply**:
```
provider "google" {
  version = "3.64.0"
}
resource "google_service_account" "account" {
  account_id   = "account"
  project      = local.project_id
}
resource "google_service_account_key" "account_key" {
  service_account_id = google_service_account.account.account_id
}
```
```
Error: project: required field is not set
```

While this works:
```
provider "google" {
  version = "3.64.0"
}
resource "google_service_account" "account" {
  account_id   = "account"
  project      = local.project_id
}
resource "google_service_account_key" "account_key" {
  service_account_id = google_service_account.account.id
}
```

As the `project` field is not available on this resource, this can be very confusing. To match the behavior discussed here (https://github.com/hashicorp/terraform-provider-google/issues/7170), it might make sense to always get the `project` from the `google_service_account` instead, even if `account_id` is used.