### PR TITLE
Docs: Fix link to Module Registry for GCP modules

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ See the [provider reference](/docs/providers/google/guides/provider_reference.ht
 for more details on authentication or otherwise configuring the provider.
 
 Take advantage of [Modules](https://www.terraform.io/docs/modules/index.html)
-to simplify your config by browsing the [Module Registry for GCP modules](https://registry.terraform.io/browse?provider=google).
+to simplify your config by browsing the [Module Registry for GCP modules](https://registry.terraform.io/browse/modules?provider=google).
 
 The Google provider is jointly maintained by:
 


### PR DESCRIPTION
Current link takes you to a list of providers instead