### PR TITLE
Update compute_region_instance_group_manager.html.markdown to show version -> name is optional not required.

### DIFF
--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -225,7 +225,7 @@ version {
 }
 ```
 
-* `name` - (Required) - Version name.
+* `name` - (Optional) - Version name.
 
 * `instance_template` - (Required) - The full URL to an instance template from which all new instances of this version will be created.
 


### PR DESCRIPTION
Go code says that it is optional, and in practice it is.  Just noticed it while trying to understand a diff and thought I'd update.