### PR TITLE
cloudfunctions: allow to configure `trigger_http` security level

### DIFF
--- a/google/data_source_google_cloudfunctions_function_test.go
+++ b/google/data_source_google_cloudfunctions_function_test.go
@@ -53,7 +53,7 @@ resource "google_cloudfunctions_function" "function_http" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 61
   entry_point           = "helloGET"
 }

--- a/google/iam_cloudfunctions_function_generated_test.go
+++ b/google/iam_cloudfunctions_function_generated_test.go
@@ -139,7 +139,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 60
   entry_point           = "helloGET"
 }
@@ -174,7 +174,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 60
   entry_point           = "helloGET"
 }
@@ -215,7 +215,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 60
   entry_point           = "helloGET"
 }
@@ -252,7 +252,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 60
   entry_point           = "helloGET"
 }
@@ -287,7 +287,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 60
   entry_point           = "helloGET"
 }

--- a/google/resource_cloudfunctions_function_test.go
+++ b/google/resource_cloudfunctions_function_test.go
@@ -154,7 +154,7 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(funcResourceName,
 						"entry_point", "helloGET"),
 					resource.TestCheckResourceAttr(funcResourceName,
-						"trigger_http", "true"),
+						"trigger_http", "SECURE_ALWAYS"),
 					testAccCloudFunctionsFunctionHasLabel("my-label", "my-label-value", &function),
 					testAccCloudFunctionsFunctionHasEnvironmentVariable("TEST_ENV_VARIABLE",
 						"test-env-variable-value", &function),
@@ -608,7 +608,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 61
   entry_point           = "helloGET"
   ingress_settings      = "ALLOW_INTERNAL_ONLY"
@@ -644,7 +644,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 256
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   runtime               = "nodejs10"
   timeout               = 91
   entry_point           = "helloGET"
@@ -809,7 +809,7 @@ resource "google_cloudfunctions_function" "function" {
     url = "https://source.developers.google.com/projects/%s/repos/cloudfunctions-test-do-not-delete/moveable-aliases/master/paths/"
   }
 
-  trigger_http = true
+  trigger_http = "SECURE_ALWAYS"
   entry_point  = "helloGET"
 }
 `, functionName, project)
@@ -839,7 +839,7 @@ resource "google_cloudfunctions_function" "function" {
 
   service_account_email = data.google_compute_default_service_account.default.email
 
-  trigger_http = true
+  trigger_http = "SECURE_ALWAYS"
   entry_point  = "helloGET"
 }
 `, bucketName, zipFilePath, functionName)
@@ -883,7 +883,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 61
   entry_point           = "helloGET"
   labels = {

--- a/google/resource_compute_region_network_endpoint_group_generated_test.go
+++ b/google/resource_compute_region_network_endpoint_group_generated_test.go
@@ -69,7 +69,7 @@ resource "google_cloudfunctions_function" "function_neg" {
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  trigger_http          = true
+  trigger_http          = "SECURE_ALWAYS"
   timeout               = 60
   entry_point           = "helloGET"
 }


### PR DESCRIPTION
- This is not a backwards compatible change
- Possible values are `SECURE_OPTIONAL` (http/s) and `SECURE_ALWAYS` (https)