### PR TITLE
Docs update for `google_compute_global_address`

### DIFF
--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -113,7 +113,7 @@ or addressType=INTERNAL when purpose=PRIVATE_SERVICE_CONNECT`,
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Description: `The purpose of the resource. Possible values include:
+				Description: `The purpose of the resource. This field cannot be specified with `EXTERNAL` address_type. Possible values include:
 
 * VPC_PEERING - for peer networks
 

--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -113,11 +113,14 @@ or addressType=INTERNAL when purpose=PRIVATE_SERVICE_CONNECT`,
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Description: `The purpose of the resource. This field cannot be specified with `EXTERNAL` address_type. Possible values include:
-
-* VPC_PEERING - for peer networks
-
-* PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks`,
+				Description: `The purpose of the resource. Possible values include:
+* GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, load balancers, and similar resources.
+* DNS_RESOLVER for a DNS resolver address in a subnetwork for a Cloud DNS [inbound forwarder IP addresses](https://cloud.google.com/dns/docs/policies#create-in) (regional internal IP address in a subnet of a VPC network)
+* VPC_PEERING for global internal IP addresses used for [private services access allocated ranges](https://cloud.google.com/vpc/docs/configure-private-services-access#allocating-range).
+* NAT_AUTO for the regional external IP addresses used by Cloud NAT when allocating addresses using automatic NAT IP address allocation.
+* IPSEC_INTERCONNECT for addresses created from a private IP range that are reserved for a VLAN attachment in an IPsec-encrypted Cloud Interconnect configuration. These addresses are regional resources. Not currently available publicly.
+* SHARED_LOADBALANCER_VIP for an internal IP address that is assigned to multiple internal forwarding rules.
+* PRIVATE_SERVICE_CONNECT for a private network address that is used to configure Private Service Connect. Only global internal addresses can use this purpose.`,
 			},
 			"creation_timestamp": {
 				Type:        schema.TypeString,

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 * `purpose` -
   (Optional)
-  The purpose of the resource. Possible values include:
+  The purpose of the resource. This field cannot be specified with `EXTERNAL` address_type. Possible values include:
   * VPC_PEERING - for peer networks
   * PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks
 

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -125,9 +125,14 @@ The following arguments are supported:
 
 * `purpose` -
   (Optional)
-  The purpose of the resource. This field cannot be specified with `EXTERNAL` address_type. Possible values include:
-  * VPC_PEERING - for peer networks
-  * PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks
+  The purpose of the resource. Possible values include:
+  * GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, load balancers, and similar resources. 
+  * DNS_RESOLVER for a DNS resolver address in a subnetwork for a Cloud DNS [inbound forwarder IP addresses](https://cloud.google.com/dns/docs/policies#create-in) (regional internal IP address in a subnet of a VPC network)
+  * VPC_PEERING for global internal IP addresses used for [private services access allocated ranges](https://cloud.google.com/vpc/docs/configure-private-services-access#allocating-range).
+  * NAT_AUTO for the regional external IP addresses used by Cloud NAT when allocating addresses using automatic NAT IP address allocation.
+  * IPSEC_INTERCONNECT for addresses created from a private IP range that are reserved for a VLAN attachment in an IPsec-encrypted Cloud Interconnect configuration. These addresses are regional resources. Not currently available publicly.
+  * SHARED_LOADBALANCER_VIP for an internal IP address that is assigned to multiple internal forwarding rules.
+  * PRIVATE_SERVICE_CONNECT for a private network address that is used to configure Private Service Connect. Only global internal addresses can use this purpose.
 
 * `network` -
   (Optional)


### PR DESCRIPTION
Hi, 

I got this error when `terraform apply`. 

```
│ Error: Error creating GlobalAddress: googleapi: Error 400: Invalid value for field 'resource.purpose': 'VPC_PEERING'. The field cannot be specified with external address., invalid
│ 
│   with google_compute_global_address.static_ip["foo"],
│   on main.tf line 37, in resource "google_compute_global_address" "static_ip":
│   37: resource "google_compute_global_address" "static_ip" {
│ 
```

I think `The field cannot be specified with external address.` should be on the document to prevent this error before `terraform apply`.