### PR TITLE
Fix account_id syntax in google_compute_instance docs

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -18,7 +18,7 @@ and
 
 ```hcl
 resource "google_service_account" "default" {
-  account_id   = "service_account_id"
+  account_id   = "service-account-id"
   display_name = "Service Account"
 }
 


### PR DESCRIPTION
- account_id cannot contain underscores