### PR TITLE
Add Learn links to GCP provider docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -11,6 +11,9 @@ description: |-
 The Google provider is used to configure your [Google Cloud Platform](https://cloud.google.com/) infrastructure.
 See the [Getting Started](/docs/providers/google/guides/getting_started.html) page for an introduction to using the provider.
 
+To learn the basics of Terraform using this provider, follow the
+hands-on [get started tutorials](https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/gcp-get-started) on HashiCorp's Learn platform. For a more involved examples, try [provisioning a GKE cluster](https://learn.hashicorp.com/tutorials/terraform/gke) and deploying [Consul-backed Vault into it using Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/kubernetes-consul-vault-pipeline).
+
 A typical provider configuration will look something like:
 
 ```hcl

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -12,7 +12,7 @@ The Google provider is used to configure your [Google Cloud Platform](https://cl
 See the [Getting Started](/docs/providers/google/guides/getting_started.html) page for an introduction to using the provider.
 
 To learn the basics of Terraform using this provider, follow the
-hands-on [get started tutorials](https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/gcp-get-started) on HashiCorp's Learn platform. For a more involved examples, try [provisioning a GKE cluster](https://learn.hashicorp.com/tutorials/terraform/gke) and deploying [Consul-backed Vault into it using Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/kubernetes-consul-vault-pipeline).
+hands-on [get started tutorials](https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/gcp-get-started) on HashiCorp's Learn platform. For more involved examples, try [provisioning a GKE cluster](https://learn.hashicorp.com/tutorials/terraform/gke) and deploying [Consul-backed Vault into it using Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/kubernetes-consul-vault-pipeline).
 
 A typical provider configuration will look something like:
 


### PR DESCRIPTION
Add links to our GCP tutorials to the documentation for the GCP provider. This format mirrors the cross links we have in the docs for the AWS provider, but please let me know if something different would be better :) 