### PR TITLE
Change terminology to use 'published' in place of 'upstream' in documentation 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool_basic'
 
 The `TESTARGS` variable is regexp-like, so multiple tests can be run in parallel by specifying a common substring of those tests (for example, `TestAccContainerNodePool` to run all node pool tests). There are 1500+ tests, and running all of them takes over 4 hours and requires a lot of GCP quota.
 
-### Ensuring no plan-time difference to upstream provider
+### Ensuring no plan-time difference to published provider
 
 To ensure the resource you are modifying doesn't result in diff to existing deployments you can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `UPSTREAM_DIFF` before running a test. This will append plan only steps using the downstream - published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity. This is recommended when you are modifying existing fields and do not want to break existing user deployments.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,12 +53,12 @@ make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool_basic'
 
 The `TESTARGS` variable is regexp-like, so multiple tests can be run in parallel by specifying a common substring of those tests (for example, `TestAccContainerNodePool` to run all node pool tests). There are 1500+ tests, and running all of them takes over 4 hours and requires a lot of GCP quota.
 
-### Ensuring no plan-time difference to published provider
+### Ensuring no plan-time difference to published provider (optional)
 
-To ensure the resource you are modifying doesn't result in diff to existing deployments you can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `DOWNSTREAM_DIFF` before running a test. This will append plan only steps using the downstream - published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity. This is recommended when you are modifying existing fields and do not want to break existing user deployments.
+In a case where you are editing an existing field you might want to ensure the resource you are modifying doesn't result in a diff to existing deployments. You can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `RELEASE_DIFF` before running a test. This will append plan only steps using the latest released/published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity.
 
 ```
-export UPSTREAM_DIFF=true
+export RELEASE_DIFF=true
 make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool_basic'
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The `TESTARGS` variable is regexp-like, so multiple tests can be run in parallel
 
 ### Ensuring no plan-time difference to upstream provider
 
-To ensure the resource you are modifying doesn't result in diff to existing deployments you can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `UPSTREAM_DIFF` before running a test. This will append plan only steps using the upstream provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity. This is recommended when you are modifying existing fields and do not want to break existing user deployments.
+To ensure the resource you are modifying doesn't result in diff to existing deployments you can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `UPSTREAM_DIFF` before running a test. This will append plan only steps using the downstream - published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity. This is recommended when you are modifying existing fields and do not want to break existing user deployments.
 
 ```
 export UPSTREAM_DIFF=true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The `TESTARGS` variable is regexp-like, so multiple tests can be run in parallel
 
 ### Ensuring no plan-time difference to published provider
 
-To ensure the resource you are modifying doesn't result in diff to existing deployments you can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `UPSTREAM_DIFF` before running a test. This will append plan only steps using the downstream - published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity. This is recommended when you are modifying existing fields and do not want to break existing user deployments.
+To ensure the resource you are modifying doesn't result in diff to existing deployments you can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `DOWNSTREAM_DIFF` before running a test. This will append plan only steps using the downstream - published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity. This is recommended when you are modifying existing fields and do not want to break existing user deployments.
 
 ```
 export UPSTREAM_DIFF=true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ make testacc TEST=./google TESTARGS='-run=TestAccContainerNodePool_basic'
 
 The `TESTARGS` variable is regexp-like, so multiple tests can be run in parallel by specifying a common substring of those tests (for example, `TestAccContainerNodePool` to run all node pool tests). There are 1500+ tests, and running all of them takes over 4 hours and requires a lot of GCP quota.
 
-### Ensuring no plan-time difference to published provider (optional)
+### Ensuring no plan-time difference to latest provider release (optional)
 
 In a case where you are editing an existing field you might want to ensure the resource you are modifying doesn't result in a diff to existing deployments. You can run set the [environment variable](https://github.com/GoogleCloudPlatform/magic-modules/blob/a30da2040ca7b8bd37186d8521a911e7469da632/mmv1/third_party/terraform/utils/provider_test.go.erb#L284-L286) `RELEASE_DIFF` before running a test. This will append plan only steps using the latest released/published provider (`google` or `google-beta`) after all configuration deployments to ensure uniformity.
 


### PR DESCRIPTION
I was misusing this terminology in the description. Corrected

@rileykarson 

Do you think I should rename the env variable?