### PR TITLE
Enable to specify ip_address in resource_compute_rooter_peer

### DIFF
--- a/google/resource_compute_router_peer.go
+++ b/google/resource_compute_router_peer.go
@@ -161,6 +161,7 @@ If it is not provided, the provider region is used.`,
 			"ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 				Description: `IP address of the interface inside Google Cloud Platform.
 Only IPv4 is supported.`,
 			},
@@ -209,6 +210,13 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("interface"); !isEmptyValue(reflect.ValueOf(interfaceNameProp)) && (ok || !reflect.DeepEqual(v, interfaceNameProp)) {
 		obj["interfaceName"] = interfaceNameProp
 	}
+	ipAddressProp, err := expandNestedComputeRouterBgpPeerIpAddress(d.Get("ip_address"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("ip_address"); !isEmptyValue(reflect.ValueOf(ipAddressProp)) && (ok || !reflect.DeepEqual(v, ipAddressProp)) {
+		obj["ipAddress"] = ipAddressProp
+	}
+
 	peerIpAddressProp, err := expandNestedComputeRouterBgpPeerPeerIpAddress(d.Get("peer_ip_address"), d, config)
 	if err != nil {
 		return err
@@ -409,6 +417,14 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	billingProject = project
 
 	obj := make(map[string]interface{})
+
+	ipAddressProp, err := expandNestedComputeRouterBgpPeerIpAddress(d.Get("ip_address"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("ip_address"); !isEmptyValue(reflect.ValueOf(ipAddressProp)) && (ok || !reflect.DeepEqual(v, ipAddressProp)) {
+		obj["ipAddress"] = ipAddressProp
+	}
+
 	peerIpAddressProp, err := expandNestedComputeRouterBgpPeerPeerIpAddress(d.Get("peer_ip_address"), d, config)
 	if err != nil {
 		return err
@@ -680,6 +696,9 @@ func expandNestedComputeRouterBgpPeerName(v interface{}, d TerraformResourceData
 }
 
 func expandNestedComputeRouterBgpPeerInterface(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+func expandNestedComputeRouterBgpPeerIpAddress(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/website/docs/r/compute_router_peer.html.markdown
+++ b/website/docs/r/compute_router_peer.html.markdown
@@ -65,6 +65,22 @@ resource "google_compute_router_peer" "peer" {
  }
 ```
 
+## Example Usage - Router Peer specify IP address explicitly
+
+
+```hcl
+resource "google_compute_router_peer" "peer" {
+  name                      = "my-router-peer"
+  router                    = "my-router"
+  region                    = "us-central1"
+  ip_address                = "169.254.1.1"
+  peer_ip_address           = "169.254.1.2"
+  peer_asn                  = 65513
+  advertised_route_priority = 100
+  interface                 = "interface-1"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -82,6 +98,10 @@ The following arguments are supported:
 * `interface` -
   (Required)
   Name of the interface the BGP peer is associated with.
+
+* `ip_address` -
+  IP address of the interface inside Google Cloud Platform.
+  Only IPv4 is supported.
 
 * `peer_ip_address` -
   (Required)
@@ -168,10 +188,6 @@ The `advertised_ip_ranges` block supports:
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/regions/{{region}}/routers/{{router}}/{{name}}`
-
-* `ip_address` -
-  IP address of the interface inside Google Cloud Platform.
-  Only IPv4 is supported.
 
 * `management_type` -
   The resource that configures and manages this BGP peer.


### PR DESCRIPTION
resolves: https://github.com/hashicorp/terraform-provider-google/issues/9815

Enabled to specify `ip_address` property of `resource_compute_rooter_peer` which now is always computed.