### PR TITLE
bugfix: remove duplicate path in url for google_bigquery_dataset_iam_policy resource

### DIFF
--- a/google/iam_bigquery_dataset.go
+++ b/google/iam_bigquery_dataset.go
@@ -74,7 +74,7 @@ func BigqueryDatasetIdParseFunc(d *schema.ResourceData, config *Config) error {
 }
 
 func (u *BigqueryDatasetIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-	url := fmt.Sprintf("%s%s", u.Config.BigQueryBasePath, u.GetResourceId())
+	url := fmt.Sprintf("%s%s", u.Config.BigQueryBasePath, u.datasetId)
 
 	userAgent, err := generateUserAgentString(u.d, u.Config.userAgent)
 	if err != nil {
@@ -94,7 +94,7 @@ func (u *BigqueryDatasetIamUpdater) GetResourceIamPolicy() (*cloudresourcemanage
 }
 
 func (u *BigqueryDatasetIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Policy) error {
-	url := fmt.Sprintf("%s%s", u.Config.BigQueryBasePath, u.GetResourceId())
+	url := fmt.Sprintf("%s%s", u.Config.BigQueryBasePath, u.datasetId)
 
 	access, err := policyToAccess(policy)
 	if err != nil {


### PR DESCRIPTION
Expected behavior: Google API is called when terraform apply is run against a `google_bigquery_dataset_iam_policy` resource.

Actual behavior: Invalid Google API URLs are generated by the provider, resulting in 404s when using the `google_bigquery_dataset_iam_policy` resource.

The behavior can be seen here:

```
module.bigquery.google_bigquery_dataset_iam_policy.editor: Creating...
╷
│ Error: Error creating DatasetAccess: googleapi: got HTTP response code 404 with body: <!DOCTYPE html>
...
│   <p><b>404.</b> <ins>That’s an error.</ins>
│   <p>The requested URL <code>/bigquery/v2/projects/foo/datasets/projects/foo/datasets/bar?alt=json</code> was not found on this server.  <ins>That’s all we know.</ins>
│
│
│   with module.bigquery.google_bigquery_dataset_iam_policy.editor,
│   on ../../terraform-modules/modules/bigquery/main.tf line 59, in resource "google_bigquery_dataset_iam_policy" "editor":
│   59: resource "google_bigquery_dataset_iam_policy" "editor" {
```

Notice the duplication of `/projects/foo` in the API url. This seems to be due to the use of the `GetResourceId()` function in the generation of the URL. The terraform resource ID still seems to reflect the duplication, as seen here. This is after the API is successfully called, testing the fix locally. 

```
module.bigquery.google_bigquery_dataset_iam_policy.editor: Creating...
module.bigquery.google_bigquery_dataset_iam_policy.editor: Creation complete after 1s [id=projects/foo/datasets/projects/foo/datasets/bar]
```

I didn't know whether the correct approach was to fix the duplication present in the `GetResourceId()` function or just fix how the URL was generated. I decided to fix just the URL generation since that was the offending bug here, and I wasn't sure how else the GetResourceId function was being used. The duplication here might be intentional to avoid ResourceId collisions? I'm not quite sure.