### PR TITLE
google_service_account doc update - match the actual regular expression

### DIFF
--- a/website/docs/r/google_service_account.html.markdown
+++ b/website/docs/r/google_service_account.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `account_id` - (Required) The account id that is used to generate the service
     account email address and a stable unique id. It is unique within a project,
-    must be 6-30 characters long, and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])`
+    must be 6-30 characters long, and match the regular expression `^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$`
     to comply with RFC1035. Changing this forces a new service account to be created.
 
 * `display_name` - (Optional) The display name for the service account.


### PR DESCRIPTION
It seems like the `google_service_account` doc is not up to date and the pointed regular expression for the required `account_id` argument is different.

![image](https://user-images.githubusercontent.com/5542211/130640383-a1f56bcc-47fb-46de-b6d2-295de6670898.png)
