### PR TITLE
Updated migrate_traffic description in google_app_engine_service_split_traffic resource

### DIFF
--- a/google/resource_app_engine_service_split_traffic.go
+++ b/google/resource_app_engine_service_split_traffic.go
@@ -73,7 +73,7 @@ func resourceAppEngineServiceSplitTraffic() *schema.Resource {
 			"migrate_traffic": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: `If set to true traffic will be migrated to this version.`,
+				Description: `If set to true traffic will be migrated to this version gradually.`,
 			},
 			"project": {
 				Type:     schema.TypeString,

--- a/website/docs/r/app_engine_service_split_traffic.html.markdown
+++ b/website/docs/r/app_engine_service_split_traffic.html.markdown
@@ -126,7 +126,7 @@ The `split` block supports:
 
 * `migrate_traffic` -
   (Optional)
-  If set to true traffic will be migrated to this version.
+  If set to true traffic will be migrated to this version gradually.
 
 * `project` - (Optional) The ID of the project in which the resource belongs.
     If it is not provided, the provider project is used.


### PR DESCRIPTION
Updating description of the `migrate_traffic` variable to be more clear on it's purpose and be in line with GCP documentation.

See: https://cloud.google.com/appengine/docs/admin-api/migrating-splitting-traffic