### PR TITLE
Make Logging Sink resources work with auto-created sinks

### DIFF
--- a/google/logging_utils.go
+++ b/google/logging_utils.go
@@ -33,11 +33,11 @@ func (l LoggingSinkId) parent() string {
 	return fmt.Sprintf("%s/%s", l.resourceType, l.resourceId)
 }
 
-// parseLoggingSinkId parses a canonical id into a LoggingSinkId, or returns an error on failure.
-func parseLoggingSinkId(id string) (*LoggingSinkId, error) {
+// parseLoggingSinkParentId parses a canonical id to get sink parent resource id
+func parseLoggingSinkParentId(id string) (string, error) {
 	parts := loggingSinkIdRegex.FindStringSubmatch(id)
 	if parts == nil {
-		return nil, fmt.Errorf("unable to parse logging sink id %#v", id)
+		return "", fmt.Errorf("unable to parse logging sink id %#v", id)
 	}
 	// If our resourceType is not a valid logging sink resource type, complain loudly
 	validLoggingSinkResourceType := false
@@ -49,12 +49,8 @@ func parseLoggingSinkId(id string) (*LoggingSinkId, error) {
 	}
 
 	if !validLoggingSinkResourceType {
-		return nil, fmt.Errorf("Logging resource type %s is not valid. Valid resource types: %#v", parts[1],
+		return "", fmt.Errorf("Logging resource type %s is not valid. Valid resource types: %#v", parts[1],
 			loggingSinkResourceTypes)
 	}
-	return &LoggingSinkId{
-		resourceType: parts[1],
-		resourceId:   parts[2],
-		name:         parts[3],
-	}, nil
+	return parts[2], nil
 }

--- a/google/logging_utils_test.go
+++ b/google/logging_utils_test.go
@@ -2,25 +2,25 @@ package google
 
 import "testing"
 
-func TestParseLoggingSinkId(t *testing.T) {
+func TestParseLoggingSinkParentId(t *testing.T) {
 	tests := []struct {
 		val         string
-		out         *LoggingSinkId
+		out         string
 		errExpected bool
 	}{
-		{"projects/my-project/sinks/my-sink", &LoggingSinkId{"projects", "my-project", "my-sink"}, false},
-		{"folders/foofolder/sinks/woo", &LoggingSinkId{"folders", "foofolder", "woo"}, false},
-		{"kitchens/the-big-one/sinks/second-from-the-left", nil, true},
+		{"projects/my-project/sinks/my-sink", "my-project", false},
+		{"folders/foofolder/sinks/woo", "foofolder", false},
+		{"kitchens/the-big-one/sinks/second-from-the-left", "", true},
 	}
 
 	for _, test := range tests {
-		out, err := parseLoggingSinkId(test.val)
+		out, err := parseLoggingSinkParentId(test.val)
 		if err != nil {
 			if !test.errExpected {
 				t.Errorf("Got error with val %#v: error = %#v", test.val, err)
 			}
 		} else {
-			if *out != *test.out {
+			if out != test.out {
 				t.Errorf("Mismatch on val %#v: expected %#v but got %#v", test.val, test.out, out)
 			}
 		}

--- a/google/resource_logging_project_sink_test.go
+++ b/google/resource_logging_project_sink_test.go
@@ -552,10 +552,11 @@ resource "google_logging_project_sink" "default" {
 }
 
 resource "google_logging_project_bucket_config" "new_bucket" {
+	project        = "%s"
 	bucket_id      = "%s"
 	location       = "global"
 	retention_days = 30
 	description    = "test logging bucket"
 }
-`, project, bucketName)
+`, project, project, bucketName)
 }

--- a/google/resource_logging_sink.go
+++ b/google/resource_logging_sink.go
@@ -2,212 +2,204 @@ package google
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"google.golang.org/api/logging/v2"
+	"log"
+	"strconv"
 )
 
-func resourceLoggingSinkSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"name": {
-			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
-			Description: `The name of the logging sink.`,
-		},
+var loggingSinkSchema = map[string]*schema.Schema{
+	"name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: `The name of the logging sink.`,
+	},
 
-		"destination": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: `The destination of the sink (or, in other words, where logs are written to). Can be a Cloud Storage bucket, a PubSub topic, or a BigQuery dataset. Examples: "storage.googleapis.com/[GCS_BUCKET]" "bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET]" "pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]" The writer associated with the sink must have access to write to the above resource.`,
-		},
+	"destination": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: `The destination of the sink (or, in other words, where logs are written to). Can be a Cloud Storage bucket, a PubSub topic, or a BigQuery dataset. Examples: "storage.googleapis.com/[GCS_BUCKET]" "bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET]" "pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]" The writer associated with the sink must have access to write to the above resource.`,
+	},
 
-		"filter": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			DiffSuppressFunc: optionalSurroundingSpacesSuppress,
-			Description:      `The filter to apply when exporting logs. Only log entries that match the filter are exported.`,
-		},
+	"filter": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		DiffSuppressFunc: optionalSurroundingSpacesSuppress,
+		Description:      `The filter to apply when exporting logs. Only log entries that match the filter are exported.`,
+	},
 
-		"description": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: `A description of this sink. The maximum length of the description is 8000 characters.`,
-		},
+	"description": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: `A description of this sink. The maximum length of the description is 8000 characters.`,
+	},
 
-		"disabled": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: `If set to True, then this sink is disabled and it does not export any log entries.`,
-		},
+	"disabled": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: `If set to True, then this sink is disabled and it does not export any log entries.`,
+	},
 
-		"exclusions": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: `Log entries that match any of the exclusion filters will not be exported. If a log entry is matched by both filter and one of exclusion_filters it will not be exported.`,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: `A client-assigned identifier, such as "load-balancer-exclusion". Identifiers are limited to 100 characters and can include only letters, digits, underscores, hyphens, and periods. First character has to be alphanumeric.`,
-					},
-					"description": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: `A description of this exclusion.`,
-					},
-					"filter": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
-					},
-					"disabled": {
-						Type:        schema.TypeBool,
-						Optional:    true,
-						Default:     false,
-						Description: `If set to True, then this exclusion is disabled and it does not exclude any log entries`,
-					},
+	"exclusions": {
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: `Log entries that match any of the exclusion filters will not be exported. If a log entry is matched by both filter and one of exclusion_filters it will not be exported.`,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: `A client-assigned identifier, such as "load-balancer-exclusion". Identifiers are limited to 100 characters and can include only letters, digits, underscores, hyphens, and periods. First character has to be alphanumeric.`,
+				},
+				"description": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: `A description of this exclusion.`,
+				},
+				"filter": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
+				},
+				"disabled": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: `If set to True, then this exclusion is disabled and it does not exclude any log entries`,
 				},
 			},
 		},
+	},
 
-		"writer_identity": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: `The identity associated with this sink. This identity must be granted write access to the configured destination.`,
-		},
+	"writer_identity": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: `The identity associated with this sink. This identity must be granted write access to the configured destination.`,
+	},
 
-		"bigquery_options": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Computed:    true,
-			MaxItems:    1,
-			Description: `Options that affect sinks exporting data to BigQuery.`,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"use_partitioned_tables": {
-						Type:        schema.TypeBool,
-						Required:    true,
-						Description: `Whether to use BigQuery's partition tables. By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned tables the date suffix is no longer present and special query syntax has to be used instead. In both cases, tables are sharded based on UTC timezone.`,
-					},
+	"bigquery_options": {
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		MaxItems:    1,
+		Description: `Options that affect sinks exporting data to BigQuery.`,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"use_partitioned_tables": {
+					Type:        schema.TypeBool,
+					Required:    true,
+					Description: `Whether to use BigQuery's partition tables. By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned tables the date suffix is no longer present and special query syntax has to be used instead. In both cases, tables are sharded based on UTC timezone.`,
 				},
 			},
 		},
+	},
+}
+
+func resourceLoggingSinkSchema(parentSpecificSchema map[string]*schema.Schema) map[string]*schema.Schema {
+	return mergeSchemas(loggingSinkSchema, parentSpecificSchema)
+}
+
+type loggingSinkIDFunc func(d *schema.ResourceData, config *Config) (string, error)
+type loggingSinkCreateFunc func(d *schema.ResourceData, meta interface{}) error
+type loggingSinkReadFunc func(d *schema.ResourceData, meta interface{}) error
+type loggingSinkUpdateFunc func(d *schema.ResourceData, meta interface{}) error
+
+func resourceLoggingSinkAcquireOrCreate(iDFunc loggingSinkIDFunc, sinkCreateFunc loggingSinkCreateFunc, sinkUpdateFunc loggingSinkUpdateFunc) func(*schema.ResourceData, interface{}) error {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
+		userAgent, err := generateUserAgentString(d, config.userAgent)
+		if err != nil {
+			return err
+		}
+
+		id, err := iDFunc(d, config)
+		if err != nil {
+			return err
+		}
+
+		d.SetId(id)
+		log.Printf("[DEBUG] Fetching Logging Sink: %#v", d.Id())
+		url, err := replaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", d.Id()))
+		if err != nil {
+			return err
+		}
+
+		res, _ := sendRequest(config, "GET", "", url, userAgent, nil)
+		if res == nil {
+			log.Printf("[DEGUG] Logging Sink does not exist %s", d.Id())
+			return sinkCreateFunc(d, meta)
+		}
+
+		return sinkUpdateFunc(d, meta)
 	}
 }
 
-func expandResourceLoggingSink(d *schema.ResourceData, resourceType, resourceId string) (LoggingSinkId, *logging.LogSink) {
-	id := LoggingSinkId{
-		resourceType: resourceType,
-		resourceId:   resourceId,
-		name:         d.Get("name").(string),
-	}
+type loggingSinksPathFunc func(d *schema.ResourceData, config *Config) (string, error)
+type expandForCreateFunc func(d *schema.ResourceData, config *Config) (map[string]interface{}, bool)
 
-	sink := logging.LogSink{
-		Name:            d.Get("name").(string),
-		Destination:     d.Get("destination").(string),
-		Filter:          d.Get("filter").(string),
-		Description:     d.Get("description").(string),
-		Disabled:        d.Get("disabled").(bool),
-		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
-		BigqueryOptions: expandLoggingSinkBigqueryOptions(d.Get("bigquery_options")),
+func resourceLoggingSinkCreate(loggingSinksPath loggingSinksPathFunc, expandForCreate expandForCreateFunc, sinkReadFunc loggingSinkReadFunc) func(d *schema.ResourceData, meta interface{}) error {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
+		userAgent, err := generateUserAgentString(d, config.userAgent)
+		if err != nil {
+			return err
+		}
+
+		sinksPath, err := loggingSinksPath(d, config)
+		if err != nil {
+			return err
+		}
+		url, err := replaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", sinksPath))
+		if err != nil {
+			return err
+		}
+
+		obj, uniqueWriterIdentity := expandForCreate(d, config)
+		url, err = addQueryParams(url, map[string]string{
+			"uniqueWriterIdentity": strconv.FormatBool(uniqueWriterIdentity),
+		})
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Creating new Logging Sink: %#v", obj)
+		billingProject := ""
+
+		project, err := getProject(d, config)
+		if err != nil {
+			return err
+		}
+		billingProject = project
+
+		// err == nil indicates that the billing_project value was found
+		if bp, err := getBillingProject(d, config); err == nil {
+			billingProject = bp
+		}
+
+		res, err := sendRequestWithTimeout(config, "POST", billingProject, url, userAgent, obj, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return fmt.Errorf("Error creating Logging Sink: %s", err)
+		}
+
+		log.Printf("[DEBUG] Finished creating Logging Sink %q: %#v", d.Id(), res)
+
+		return sinkReadFunc(d, meta)
 	}
-	return id, &sink
 }
 
-func flattenResourceLoggingSink(d *schema.ResourceData, sink *logging.LogSink) error {
-	if err := d.Set("name", sink.Name); err != nil {
-		return fmt.Errorf("Error setting name: %s", err)
-	}
-	if err := d.Set("destination", sink.Destination); err != nil {
-		return fmt.Errorf("Error setting destination: %s", err)
-	}
-	if err := d.Set("filter", sink.Filter); err != nil {
-		return fmt.Errorf("Error setting filter: %s", err)
-	}
-	if err := d.Set("description", sink.Description); err != nil {
-		return fmt.Errorf("Error setting description: %s", err)
-	}
-	if err := d.Set("disabled", sink.Disabled); err != nil {
-		return fmt.Errorf("Error setting disabled: %s", err)
-	}
-	if err := d.Set("writer_identity", sink.WriterIdentity); err != nil {
-		return fmt.Errorf("Error setting writer_identity: %s", err)
-	}
-	if err := d.Set("exclusions", flattenLoggingSinkExclusion(sink.Exclusions)); err != nil {
-		return fmt.Errorf("Error setting exclusions: %s", err)
-	}
-	if err := d.Set("bigquery_options", flattenLoggingSinkBigqueryOptions(sink.BigqueryOptions)); err != nil {
-		return fmt.Errorf("Error setting bigquery_options: %s", err)
-	}
-
-	return nil
-}
-
-func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.LogSink, updateMask string) {
-	// Can only update destination/filter right now. Despite the method below using 'Patch', the API requires both
-	// destination and filter (even if unchanged).
-	sink = &logging.LogSink{
-		Destination:     d.Get("destination").(string),
-		Filter:          d.Get("filter").(string),
-		Disabled:        d.Get("disabled").(bool),
-		ForceSendFields: []string{"Destination", "Filter", "Disabled"},
-	}
-
-	updateFields := []string{}
-	if d.HasChange("destination") {
-		updateFields = append(updateFields, "destination")
-	}
-	if d.HasChange("filter") {
-		updateFields = append(updateFields, "filter")
-	}
-	if d.HasChange("description") {
-		updateFields = append(updateFields, "description")
-	}
-	if d.HasChange("disabled") {
-		updateFields = append(updateFields, "disabled")
-	}
-	if d.HasChange("exclusions") {
-		sink.Exclusions = expandLoggingSinkExclusions(d.Get("exclusions"))
-		updateFields = append(updateFields, "exclusions")
-	}
-	if d.HasChange("bigquery_options") {
-		sink.BigqueryOptions = expandLoggingSinkBigqueryOptions(d.Get("bigquery_options"))
-		updateFields = append(updateFields, "bigqueryOptions")
-	}
-	updateMask = strings.Join(updateFields, ",")
+func expandLoggingSink(d *schema.ResourceData) (obj map[string]interface{}) {
+	obj = make(map[string]interface{})
+	obj["name"] = d.Get("name")
+	obj["description"] = d.Get("description")
+	obj["disabled"] = d.Get("disabled")
+	obj["filter"] = d.Get("filter")
+	obj["destination"] = d.Get("destination")
+	obj["exclusions"] = expandLoggingSinkExclusions(d.Get("exclusions"))
+	obj["bigqueryOptions"] = expandLoggingSinkBigqueryOptions(d.Get("bigquery_options"))
 	return
 }
 
-func expandLoggingSinkBigqueryOptions(v interface{}) *logging.BigQueryOptions {
-	if v == nil {
-		return nil
-	}
-	optionsSlice := v.([]interface{})
-	if len(optionsSlice) == 0 || optionsSlice[0] == nil {
-		return nil
-	}
-	options := optionsSlice[0].(map[string]interface{})
-	bo := &logging.BigQueryOptions{}
-	if usePartitionedTables, ok := options["use_partitioned_tables"]; ok {
-		bo.UsePartitionedTables = usePartitionedTables.(bool)
-	}
-	return bo
-}
-
-func flattenLoggingSinkBigqueryOptions(o *logging.BigQueryOptions) []map[string]interface{} {
-	if o == nil {
-		return nil
-	}
-	oMap := map[string]interface{}{
-		"use_partitioned_tables": o.UsePartitionedTables,
-	}
-	return []map[string]interface{}{oMap}
-}
-
-func expandLoggingSinkExclusions(v interface{}) []*logging.LogExclusion {
+func expandLoggingSinkExclusions(v interface{}) []map[string]interface{} {
 	if v == nil {
 		return nil
 	}
@@ -215,47 +207,227 @@ func expandLoggingSinkExclusions(v interface{}) []*logging.LogExclusion {
 	if len(exclusions) == 0 {
 		return nil
 	}
-	results := make([]*logging.LogExclusion, 0, len(exclusions))
+	results := make([]map[string]interface{}, 0, len(exclusions))
 	for _, e := range exclusions {
 		exclusion := e.(map[string]interface{})
-		results = append(results, &logging.LogExclusion{
-			Name:        exclusion["name"].(string),
-			Description: exclusion["description"].(string),
-			Filter:      exclusion["filter"].(string),
-			Disabled:    exclusion["disabled"].(bool),
+		results = append(results, map[string]interface{}{
+			"name":        exclusion["name"].(string),
+			"description": exclusion["description"].(string),
+			"filter":      exclusion["filter"].(string),
+			"disabled":    exclusion["disabled"].(bool),
 		})
 	}
 	return results
 }
 
-func flattenLoggingSinkExclusion(exclusions []*logging.LogExclusion) []map[string]interface{} {
-	if exclusions == nil {
+func expandLoggingSinkBigqueryOptions(v interface{}) map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	bigQueryOptions := v.([]interface{})
+	if len(bigQueryOptions) == 0 || bigQueryOptions[0] == nil {
+		return nil
+	}
+	options := bigQueryOptions[0].(map[string]interface{})
+	bo := make(map[string]interface{})
+	if usePartitionedTables, ok := options["use_partitioned_tables"]; ok {
+		bo["usePartitionedTables"] = usePartitionedTables.(bool)
+	}
+	return bo
+}
+
+type flattenLoggingSinkFunc func(d *schema.ResourceData, res map[string]interface{}, config *Config) error
+
+func resourceLoggingSinkRead(flattenLoginSink flattenLoggingSinkFunc) func(*schema.ResourceData, interface{}) error {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
+		userAgent, err := generateUserAgentString(d, config.userAgent)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Fetching Logging Sink: %#v", d.Id())
+
+		url, err := replaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", d.Id()))
+		if err != nil {
+			return err
+		}
+
+		res, err := sendRequest(config, "GET", "", url, userAgent, nil)
+		if err != nil {
+			log.Printf("[WARN] Unable to acquire Logging Sink at %s", d.Id())
+
+			d.SetId("")
+			return err
+		}
+
+		return flattenLoginSink(d, res, config)
+	}
+}
+
+func flattenLoggingSinkBase(d *schema.ResourceData, res map[string]interface{}) error {
+	if err := d.Set("name", res["name"]); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
+	if err := d.Set("description", res["description"]); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("disabled", res["disabled"]); err != nil {
+		return fmt.Errorf("Error setting disabled: %s", err)
+	}
+	if err := d.Set("filter", res["filter"]); err != nil {
+		return fmt.Errorf("Error setting filter: %s", err)
+	}
+	if err := d.Set("destination", res["destination"]); err != nil {
+		return fmt.Errorf("Error setting destination: %s", err)
+	}
+	if err := d.Set("writer_identity", res["writerIdentity"]); err != nil {
+		return fmt.Errorf("Error setting writer_identity: %s", err)
+	}
+	if err := d.Set("exclusions", flattenLoggingSinkExclusions(res["exclusions"])); err != nil {
+		return fmt.Errorf("Error setting exclusions: %s", err)
+	}
+	if err := d.Set("bigquery_options", flattenLoggingSinkBigqueryOptions(res["bigqueryOptions"])); err != nil {
+		return fmt.Errorf("Error setting bigquery_options: %s", err)
+	}
+	return nil
+}
+
+func flattenLoggingSinkExclusions(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	exclusions := v.([]interface{})
+	if len(exclusions) == 0 {
 		return nil
 	}
 	flattenedExclusions := make([]map[string]interface{}, 0, len(exclusions))
 	for _, e := range exclusions {
+		exclusion := e.(map[string]interface{})
 		flattenedExclusion := map[string]interface{}{
-			"name":        e.Name,
-			"description": e.Description,
-			"filter":      e.Filter,
-			"disabled":    e.Disabled,
+			"name":        exclusion["name"],
+			"description": exclusion["description"],
+			"filter":      exclusion["filter"],
+			"disabled":    exclusion["disabled"],
 		}
 		flattenedExclusions = append(flattenedExclusions, flattenedExclusion)
-
 	}
-
 	return flattenedExclusions
 }
 
-func resourceLoggingSinkImportState(sinkType string) schema.StateFunc {
+func flattenLoggingSinkBigqueryOptions(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	bigqueryOptions := v.(map[string]interface{})
+	oMap := map[string]interface{}{
+		"use_partitioned_tables": bigqueryOptions["usePartitionedTables"],
+	}
+	return []map[string]interface{}{oMap}
+}
+
+type expandLoggingSinkForUpdateFunc func(d *schema.ResourceData, config *Config) (map[string]interface{}, string, bool)
+
+func resourceLoggingSinkUpdate(expandLoggingSinkForUpdate expandLoggingSinkForUpdateFunc, sinkReadFunc loggingSinkReadFunc) func(*schema.ResourceData, interface{}) error {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		config := meta.(*Config)
+		userAgent, err := generateUserAgentString(d, config.userAgent)
+		if err != nil {
+			return err
+		}
+
+		url, err := replaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", d.Id()))
+		if err != nil {
+			return err
+		}
+
+		obj, updateMask, uniqueWriterIdentity := expandLoggingSinkForUpdate(d, config)
+		url, err = addQueryParams(url, map[string]string{
+			"updateMask":           updateMask,
+			"uniqueWriterIdentity": strconv.FormatBool(uniqueWriterIdentity),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = sendRequestWithTimeout(config, "PATCH", "", url, userAgent, obj, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("Error updating Logging Sink %q: %s", d.Id(), err)
+		}
+
+		return sinkReadFunc(d, meta)
+	}
+}
+
+func expandResourceLoggingSinkForUpdateBase(d *schema.ResourceData) (obj map[string]interface{}, updateFields []string) {
+	// Can only update destination/filter right now. Despite the method below using 'Patch', the API requires both
+	// destination and filter (even if unchanged).
+	obj = make(map[string]interface{})
+	updateFields = []string{}
+	if d.HasChange("destination") {
+		obj["destination"] = d.Get("destination")
+		updateFields = append(updateFields, "destination")
+	}
+	if d.HasChange("filter") {
+		obj["filter"] = d.Get("filter")
+		updateFields = append(updateFields, "filter")
+	}
+	if d.HasChange("description") {
+		obj["description"] = d.Get("description").(string)
+		updateFields = append(updateFields, "description")
+	}
+	if d.HasChange("disabled") {
+		obj["disabled"] = d.Get("disabled").(bool)
+		updateFields = append(updateFields, "disabled")
+	}
+	if d.HasChange("exclusions") {
+		obj["exclusions"] = expandLoggingSinkExclusions(d.Get("exclusions"))
+		updateFields = append(updateFields, "exclusions")
+	}
+	if d.HasChange("bigquery_options") {
+		obj["bigqueryOptions"] = expandLoggingSinkBigqueryOptions(d.Get("bigquery_options"))
+		updateFields = append(updateFields, "bigqueryOptions")
+	}
+	return
+}
+
+func isAutomaticallyCreatedSink(d *schema.ResourceData) bool {
+	name := d.Get("name").(string)
+	return name == "_Default" || name == "_Required"
+}
+
+func resourceLoggingSinkDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	if !isAutomaticallyCreatedSink(d) {
+		userAgent, err := generateUserAgentString(d, config.userAgent)
+		if err != nil {
+			return err
+		}
+
+		url, err := replaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", d.Id()))
+		if err != nil {
+			return err
+		}
+
+		_, err = sendRequestWithTimeout(config, "DELETE", "", url, userAgent, nil, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("Error deleting Logging Sink %q: %s", d.Id(), err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceLoggingSinkImportState(idField string) schema.StateFunc {
 	return func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-		loggingSinkId, err := parseLoggingSinkId(d.Id())
+		loggingSinkParentId, err := parseLoggingSinkParentId(d.Id())
 		if err != nil {
 			return nil, err
 		}
 
-		if err := d.Set(sinkType, loggingSinkId.resourceId); err != nil {
-			return nil, fmt.Errorf("Error setting sinkType: %s", err)
+		if err := d.Set(idField, loggingSinkParentId); err != nil {
+			return nil, fmt.Errorf("Error setting idField: %s", err)
 		}
 
 		return []*schema.ResourceData{d}, nil

--- a/google/resource_logging_sink.go
+++ b/google/resource_logging_sink.go
@@ -359,8 +359,6 @@ func resourceLoggingSinkUpdate(expandLoggingSinkForUpdate expandLoggingSinkForUp
 }
 
 func expandResourceLoggingSinkForUpdateBase(d *schema.ResourceData) (obj map[string]interface{}, updateFields []string) {
-	// Can only update destination/filter right now. Despite the method below using 'Patch', the API requires both
-	// destination and filter (even if unchanged).
 	obj = make(map[string]interface{})
 	updateFields = []string{}
 	if d.HasChange("destination") {

--- a/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/website/docs/r/logging_billing_account_sink.html.markdown
@@ -18,6 +18,8 @@ description: |-
 the credentials used with Terraform. [IAM roles granted on a billing account](https://cloud.google.com/billing/docs/how-to/billing-access) are separate from the
 typical IAM roles granted on a project.
 
+~> **Note:** Logging sinks are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink from your terraform state but will leave the logging bucket unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/logging_folder_sink.html.markdown
+++ b/website/docs/r/logging_folder_sink.html.markdown
@@ -14,6 +14,7 @@ Manages a folder-level logging sink. For more information see:
 * How-to Guides
     * [Exporting Logs](https://cloud.google.com/logging/docs/export)
 
+~> **Note:** Logging sinks are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink from your terraform state but will leave the logging bucket unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
 
 ## Example Usage
 

--- a/website/docs/r/logging_organization_sink.html.markdown
+++ b/website/docs/r/logging_organization_sink.html.markdown
@@ -14,6 +14,8 @@ Manages a organization-level logging sink. For more information see:
 * How-to Guides
     * [Exporting Logs](https://cloud.google.com/logging/docs/export)
 
+~> **Note:** Logging sinks are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink from your terraform state but will leave the logging bucket unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
+
 ## Example Usage
 
 ```hcl
@@ -47,6 +49,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the logging sink.
 
 * `org_id` - (Required) The numeric ID of the organization to be exported to the sink.
+    Note that either [ORG_ID] or "organizations/[ORG_ID]" is accepted.
 
 * `destination` - (Required) The destination of the sink (or, in other words, where logs are written to). Can be a
     Cloud Storage bucket, a PubSub topic, a BigQuery dataset or a Cloud Logging bucket. Examples:

--- a/website/docs/r/logging_project_sink.html.markdown
+++ b/website/docs/r/logging_project_sink.html.markdown
@@ -21,6 +21,8 @@ Manages a project-level logging sink. For more information see:
 
 ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 
+~> **Note:** Logging sinks are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink from your terraform state but will leave the logging bucket unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
+
 ## Example Usage
 
 ```hcl
@@ -93,22 +95,23 @@ The following example uses `exclusions` to filter logs that will not be exported
 
 ```hcl
 resource "google_logging_project_sink" "log-bucket" {
-  name        = "my-logging-sink"
+  name = "my-logging-sink"
   destination = "logging.googleapis.com/projects/my-project/locations/global/buckets/_Default"
 
   exclusions {
-		name = "nsexcllusion1"
-		description = "Exclude logs from namespace-1 in k8s"
-		filter = "resource.type = k8s_container resource.labels.namespace_name=\"namespace-1\" "
-	}
+    name = "nsexcllusion1"
+    description = "Exclude logs from namespace-1 in k8s"
+    filter = "resource.type = k8s_container resource.labels.namespace_name=\"namespace-1\" "
+  }
 
-	exclusions {
-		name = "nsexcllusion2"
-		description = "Exclude logs from namespace-2 in k8s"
-		filter = "resource.type = k8s_container resource.labels.namespace_name=\"namespace-2\" "
-	}
+  exclusions {
+    name = "nsexcllusion2"
+    description = "Exclude logs from namespace-2 in k8s"
+    filter = "resource.type = k8s_container resource.labels.namespace_name=\"namespace-2\" "
+  }
 
   unique_writer_identity = true
+}
 ```
 
 


### PR DESCRIPTION
Hey, for quite a long time I wanted to re-route logs to regional logging buckets using automatically created sinks (UPDATE: which turns out to be not really possible). I saw that acquire'n'update feature already exists for logging bucket configs, but not for sinks. Hence, this PR. Another reason for this update is that it closes a gap of configuring automatically created sinks, which was mentioned in #7811.

This is my first contribution to a Terraform provider, so pls do a thorough review, because it's my first Go experience as well.