### PR TITLE
Import doc fix for google_cloudiot_device

### DIFF
--- a/website/docs/r/cloudiot_device.html.markdown
+++ b/website/docs/r/cloudiot_device.html.markdown
@@ -256,5 +256,5 @@ This resource provides the following
 Device can be imported using any of these accepted formats:
 
 ```
-$ terraform import google_cloudiot_device.default {{registry}}/devices/{{name}}
+$ terraform import google_cloudiot_device.default projects/{{project}}/locations/{{location}}/registries/{{registry}}/devices/{{name}}
 ```


### PR DESCRIPTION
The full path to the resource including project and location must
be specified; otherwise the device lookup fails with a 404 error
and the import fails.