### PR TITLE
documentation update: include bigquery_dataset resource in examples

### DIFF
--- a/website/docs/r/bigquery_dataset_iam.html.markdown
+++ b/website/docs/r/bigquery_dataset_iam.html.markdown
@@ -41,8 +41,12 @@ data "google_iam_policy" "owner" {
 }
 
 resource "google_bigquery_dataset_iam_policy" "dataset" {
-  dataset_id  = "your-dataset-id"
+  dataset_id  = google_bigquery_dataset.dataset.dataset_id
   policy_data = data.google_iam_policy.owner.policy_data
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "example_dataset"
 }
 ```
 
@@ -50,12 +54,16 @@ resource "google_bigquery_dataset_iam_policy" "dataset" {
 
 ```hcl
 resource "google_bigquery_dataset_iam_binding" "reader" {
-  dataset_id = "your-dataset-id"
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
   role       = "roles/bigquery.dataViewer"
 
   members = [
     "user:jane@example.com",
   ]
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "example_dataset"
 }
 ```
 
@@ -63,9 +71,13 @@ resource "google_bigquery_dataset_iam_binding" "reader" {
 
 ```hcl
 resource "google_bigquery_dataset_iam_member" "editor" {
-  dataset_id = "your-dataset-id"
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
   role       = "roles/bigquery.dataEditor"
   member     = "user:jane@example.com"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "example_dataset"
 }
 ```
 


### PR DESCRIPTION
This is intended to show how the dataset_id attribute should be used to reference an existing bigquery dataset. This also mirrors the format of the [bigquery_dataset_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset_access) documentation. This is intended to avoid confusion. I recently ran into this issue myself, where I only viewed the bigquery_dataset_iam docs and not the bigquery_dataset_access docs, and I used the `id` attribute instead of the `dataset_id` attribute, which caused me some trouble haha.