### PR TITLE
Redis Instance Resource no longer supports auth_string, updating docs to reflect

### DIFF
--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -240,8 +240,6 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs.
     If it is not provided, the provider project is used.
 
-* `auth_string` - (Optional) AUTH String set on the instance. This field will only be populated if auth_enabled is true.
-
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:


### PR DESCRIPTION
Support for `auth_string` for `google_redis_instance` was removed in https://github.com/GoogleCloudPlatform/magic-modules/pull/4492. But the docs were never updated to reflect this.