### PR TITLE
Added test failure issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_failure.md
+++ b/.github/ISSUE_TEMPLATE/test_failure.md
@@ -1,0 +1,26 @@
+---
+name: Test failure
+labels: test failure
+about: (Internal) For reporting test failures on the nightly builds
+title: "Failing test(s): TestAccWhatever"
+
+---
+<!--- This is a template for reporting test failures on nightly builds. It should only be used by core contributors who have access to our CI/CD results. --->
+
+<!-- i.e. "Consistently since X date" or "X% failure in MONTH" -->
+Failure rate:
+
+<!-- List all impacted tests for searchability. The title of the issue can instead list one or more groups of tests, or describe the overall root cause. -->
+Impacted tests:
+- TestAccWhatever
+
+<!-- Link to the nightly build(s), ideally with one impacted test opened -->
+Nightly builds:
+- Link
+
+<!-- The error message that displays in the tests tab, for reference -->
+Message:
+
+```
+
+```


### PR DESCRIPTION
Based on my experience reporting test failures, I think we could use this template. It would give us a more consistent data set, and help make sure we don't forget important pieces of information. It would also speed up the issue creation process by providing a nice big green button and making it so that the pre-filled issue is actually what you're wanting to fill out.