### PR TITLE
Added go:build tools line

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main


### PR DESCRIPTION
Our CI build has automatically upgraded to go 1.17.

This line seems to be added by gofmt in go 1.17, and go 1.16 doesn't mind it. I can't find documentation about it but it seems like we should add it.