### PR TITLE
Remove misleading word from the node pool - node_config docs. 

### DIFF
--- a/website/docs/r/container_node_pool.html.markdown
+++ b/website/docs/r/container_node_pool.html.markdown
@@ -147,7 +147,7 @@ cluster.
 * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
 
-* `node_config` - (Optional) Parameters used in creating the default node pool. See
+* `node_config` - (Optional) Parameters used in creating the node pool. See
     [google_container_cluster](container_cluster.html) for schema.
 
 * `network_config` - (Optional) The network configuration of the pool. See


### PR DESCRIPTION
The use of the word `default` here leads one to believe this relates to a "default" node pool as is referenced in the examples and in the cluster config settings. This block can be used for any node pool we want to setup and has nothing to do with the "default" node pool that is created when creating a cluster unless it is actually used in the cluster creation config.