### PR TITLE
Solve bug on bigquery routine documented in #10264

### DIFF
--- a/google/resource_bigquery_routine.go
+++ b/google/resource_bigquery_routine.go
@@ -55,11 +55,13 @@ If language=SQL, it is the substring inside (but excluding) the parentheses.`,
 			"dataset_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: `The ID of the dataset containing this routine`,
 			},
 			"routine_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: `The ID of the the routine. The ID must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum length is 256 characters.`,
 			},
 


### PR DESCRIPTION
See bug raised here:
https://github.com/hashicorp/terraform-provider-google/issues/10264
TLDR: dataset_id and routine_id are part of the underlying google ID for a bigquery routine and thus the resource need to be re-created and can't be "renamed"