### PR TITLE
Add warning documenting behavior of the google_service_account_key resource for certain cases where the project cannot be inferred by terraform

### DIFF
--- a/website/docs/r/google_service_account_key.html.markdown
+++ b/website/docs/r/google_service_account_key.html.markdown
@@ -15,6 +15,7 @@ Creates and manages service account keys, which allow the use of a service accou
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 
+~> **Warning:** If the `project` field in the google provider configuration is absent and the `service_account_id` field is not specified using the `{ACCOUNT}` syntax, then this resource will produce the following error: `Error: project: required field is not set`. Ensure the `service_account_id` is specified using the `{ACCOUNT}` syntax so that the project is inferred from the account.
 
 ## Example Usage, creating a new Key
 


### PR DESCRIPTION
Resolves #9617.