### PR TITLE
fixed doc for sql IAM authentication

### DIFF
--- a/google/resource_sql_user_test.go
+++ b/google/resource_sql_user_test.go
@@ -311,7 +311,7 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_user" "user" {
-  name     = "admin"
+  name     = "admin@example.com"
   instance = google_sql_database_instance.instance.name
   type     = "CLOUD_IAM_USER"
 }

--- a/website/docs/r/sql_user.html.markdown
+++ b/website/docs/r/sql_user.html.markdown
@@ -40,7 +40,7 @@ resource "google_sql_user" "users" {
 }
 ```
 
-Example creating a Cloud IAM User.
+Example creating a Cloud IAM User. (For MySQL, specify `cloudsql_iam_authentication`)
 
 ```hcl
 resource "random_id" "db_name_suffix" {
@@ -62,7 +62,7 @@ resource "google_sql_database_instance" "master" {
 }
 
 resource "google_sql_user" "users" {
-  name     = "me"
+  name     = "me@example.com"
   instance = google_sql_database_instance.master.name
   type     = "CLOUD_IAM_USER"
 }


### PR DESCRIPTION
I fixed the document for Cloud SQL IAM authentication

- I added a supplement for MySQL to the example.
- fixed test and the document for google_sql_user which is required email address for the user
  - https://cloud.google.com/sql/docs/mysql/add-manage-iam-users#rest-v1