### PR TITLE
fix: 10386

### DIFF
--- a/google/resource_essential_contacts_contact.go
+++ b/google/resource_essential_contacts_contact.go
@@ -45,6 +45,7 @@ func resourceEssentialContactsContact() *schema.Resource {
 			"email": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: `The email address to send notifications to. This does not need to be a Google account.`,
 			},
 			"language_tag": {

--- a/google/resource_essential_contacts_contact_test.go
+++ b/google/resource_essential_contacts_contact_test.go
@@ -1,0 +1,77 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEssentialContactsContact_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEssentialContactsContactDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEssentialContactsContact_v1(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_essential_contacts_contact.contact",
+						"email", "foo_v1@bar.com"),
+				),
+			},
+			{
+				ResourceName:            "google_essential_contacts_contact.contact",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccEssentialContactsContact_v2(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_essential_contacts_contact.contact",
+						"email", "foo_v2@bar.com"),
+				),
+			},
+			{
+				ResourceName:            "google_essential_contacts_contact.contact",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
+func testAccEssentialContactsContact_v1(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_essential_contacts_contact" "contact" {
+  parent = data.google_project.project.id
+  email = "foo_v1@bar.com"
+  language_tag = "en-GB"
+  notification_category_subscriptions = ["ALL"]
+}
+`, context)
+}
+
+func testAccEssentialContactsContact_v2(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_essential_contacts_contact" "contact" {
+  parent = data.google_project.project.id
+  email = "foo_v2@bar.com"
+  language_tag = "en-GB"
+  notification_category_subscriptions = ["ALL"]
+}
+`, context)
+}


### PR DESCRIPTION
for  #10386 


```
 make testacc TEST=./google TESTARGS='-run=TestAccEssentialContactsContact_update'

==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
go generate  ./...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -run=TestAccEssentialContactsContact_update -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccEssentialContactsContact_update
=== PAUSE TestAccEssentialContactsContact_update
=== CONT  TestAccEssentialContactsContact_update
--- PASS: TestAccEssentialContactsContact_update (37.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google	39.447s
```