### PR TITLE
`google_container_cluster` implement missing auto provisioning defaults fields

### DIFF
--- a/google/node_config.go
+++ b/google/node_config.go
@@ -213,7 +213,6 @@ func schemaNodeConfig() *schema.Schema {
 						},
 					},
 				},
-
 				"taint": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -2824,31 +2824,31 @@ func expandAutoProvisioningDefaults(configured interface{}, prefix string, d *sc
 	if minCPUPlatform, ok := d.GetOk(prefix + "min_cpu_platform"); ok {
 		npd.MinCpuPlatform = minCPUPlatform.(string)
 	} else {
-		npd.NullFields = append(npd.NullFields, "minCPUPlatform")
+		npd.ForceSendFields = append(npd.ForceSendFields, "minCPUPlatform")
 	}
 
 	if diskSizeGb, ok := d.GetOk(prefix + "disk_size_gb"); ok {
 		npd.DiskSizeGb = int64(diskSizeGb.(int))
 	} else {
-		npd.NullFields = append(npd.NullFields, "DiskSizeGb")
+		npd.ForceSendFields = append(npd.ForceSendFields, "DiskSizeGb")
 	}
 
 	if diskType, ok := d.GetOk(prefix + "disk_type"); ok {
 		npd.DiskType = diskType.(string)
 	} else {
-		npd.NullFields = append(npd.NullFields, "DiskType")
+		npd.ForceSendFields = append(npd.ForceSendFields, "DiskType")
 	}
 
 	if imageType, ok := d.GetOk(prefix + "image_type"); ok {
 		npd.ImageType = imageType.(string)
 	} else {
-		npd.NullFields = append(npd.NullFields, "ImageType")
+		npd.ForceSendFields = append(npd.ForceSendFields, "ImageType")
 	}
 
 	if bootDiskKmsKey, ok := d.GetOk(prefix + "boot_disk_kms_key"); ok {
 		npd.BootDiskKmsKey = bootDiskKmsKey.(string)
 	} else {
-		npd.NullFields = append(npd.NullFields, "BootDiskKmsKey")
+		npd.ForceSendFields = append(npd.ForceSendFields, "BootDiskKmsKey")
 	}
 
 	if v, ok := d.GetOk(prefix + "management"); ok && len(v.([]interface{})) > 0 {

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -2846,10 +2846,10 @@ resource "google_container_cluster" "with_autoprovisioning" {
     }
 
     auto_provisioning_defaults {
-	  disk_size_gb      = 42
-	  disk_type         = "pd-balanced"	
-      image_type        = "UBUNTU_CONTAINERD" 
-	  min_cpu_platform  = "Intel Haswell"
+      disk_size_gb      = 15
+      disk_type         = "pd-balanced"
+      image_type        = "UBUNTU_CONTAINERD"
+      min_cpu_platform  = "Intel Haswell"
 
       upgrade_settings {
         max_surge       = 3

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -2846,6 +2846,26 @@ resource "google_container_cluster" "with_autoprovisioning" {
     }
 
     auto_provisioning_defaults {
+	  disk_size_gb      = 42
+	  disk_type         = "pd-balanced"	
+      image_type        = "UBUNTU_CONTAINERD" 
+	  min_cpu_platform  = "Intel Haswell"
+
+      upgrade_settings {
+        max_surge       = 3
+        max_unavailable = 1
+      }
+
+      management {
+        auto_repair  = true
+        auto_upgrade = true
+      }
+
+      shielded_instance_config {
+        enable_secure_boot          = true
+        enable_integrity_monitoring = true
+      }
+
       oauth_scopes = [
         "https://www.googleapis.com/auth/pubsub",
         "https://www.googleapis.com/auth/devstorage.read_only",`,


### PR DESCRIPTION
This implements multiple GA fields currently missing in auto-provisioning defaults for `google_container_cluster`. 
It resolves multiple issues: #5580, #5579, #9180. 

All the settings already exist either at cluster level or in the node pool configure I used the same convention. 


### Affected Resource
`google_container_cluster`

### Terraform Configuration
```terraform
resource "google_container_cluster" "example" {
  name = "example"

  cluster_autoscaling {
    enabled = true

    auto_provisioning_defaults {
      service_account = google_service_account.cluster_nodes_service_account.email

      oauth_scopes = []

      # New options
      disk_size_gb      = 12
      disk_type         = "pd-ssd"
      boot_disk_kms_key = google_kms_crypto_key.example.id
      image_type        = "UBUNTU_CONTAINERD"
      min_cpu_platform  = "Intel Haswell"

      upgrade_settings {
        max_surge       = 1
        max_unavailable = 0
      }

      management {
        auto_repair  = true
        auto_upgrade = true
      }

      shielded_instance_config {
        enable_secure_boot          = true
        enable_integrity_monitoring = false
      }
    }
  }
}
```