### PR TITLE
Correct google_bigquery_data_transfer_config docs

### DIFF
--- a/website/docs/r/bigquery_data_transfer_config.html.markdown
+++ b/website/docs/r/bigquery_data_transfer_config.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 * `service_account_name` -
   (Optional)
-  Optional service account *email*. If this field is set, transfer config will
+  Optional service account email. If this field is set, transfer config will
   be created with this service account credentials. It requires that
   requesting user calling this API has permissions to act as this service account.
 

--- a/website/docs/r/bigquery_data_transfer_config.html.markdown
+++ b/website/docs/r/bigquery_data_transfer_config.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 * `service_account_name` -
   (Optional)
-  Optional service account name. If this field is set, transfer config will
+  Optional service account *email*. If this field is set, transfer config will
   be created with this service account credentials. It requires that
   requesting user calling this API has permissions to act as this service account.
 


### PR DESCRIPTION
`service_account_name` may be called "name" but you need to supply the *email*.

Supplying a name results in a this error: 
```Error: Error creating Config: googleapi: Error 400: Request contains an invalid argument```