### PR TITLE
Container_cluster: complete the feature of enabling GKE workload metrics

### DIFF
--- a/.changelog/5292.txt
+++ b/.changelog/5292.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-container_cluster: Updated `monitoring_config` to accept `WORKLOAD`
+container_cluster: Updated `monitoring_config` to accept `WORKLOADS`
 ```

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -540,10 +540,10 @@ func resourceContainerCluster() *schema.Resource {
 						"enable_components": {
 							Type:        schema.TypeList,
 							Required:    true,
-							Description: `GKE components exposing metrics. Valid values include SYSTEM_COMPONENTS.`,
+							Description: `GKE components exposing metrics. Valid values include SYSTEM_COMPONENTS and WORKLOADS.`,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{"SYSTEM_COMPONENTS"}, false),
+								ValidateFunc: validation.StringInSlice([]string{"SYSTEM_COMPONENTS", "WORKLOADS"}, false),
 							},
 						},
 					},

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -3723,6 +3723,23 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
+func testAccContainerCluster_withMonitoringConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  logging_config {
+	  enable_components = [ "SYSTEM_COMPONENTS", "WORKLOADS" ]
+  }
+  monitoring_config {
+	  enable_components = [ "SYSTEM_COMPONENTS", "WORKLOADS ]
+  }
+}
+`, name)
+}
+
+
 func testAccContainerCluster_withSoleTenantGroup(name string) string {
 	return fmt.Sprintf(`
 resource "google_compute_node_template" "soletenant-tmpl" {


### PR DESCRIPTION
I believe PR #10321 only updated the docs and perhaps accidentally neglected to update the associated code/tests.  When using the provider version 4.1.0 (which is post PR-10321) I get errors that `WORKLOAD` is not a valid value for `enable_components`.  