### PR TITLE
Feat: Add min_instances to cloudfunctions functions

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -293,6 +293,13 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 				Description:  `The limit on the maximum number of function instances that may coexist at a given time.`,
 			},
 
+			"min_instances": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  `The limit on the minimum number of function instances that may coexist at a given time.`,
+			},
+
 			"project": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -407,6 +414,10 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 
 	if v, ok := d.GetOk("max_instances"); ok {
 		function.MaxInstances = int64(v.(int))
+	}
+
+	if v, ok := d.GetOk("min_instances"); ok {
+		function.MinInstances = int64(v.(int))
 	}
 
 	log.Printf("[DEBUG] Creating cloud function: %s", function.Name)
@@ -527,6 +538,9 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	if err := d.Set("max_instances", function.MaxInstances); err != nil {
 		return fmt.Errorf("Error setting max_instances: %s", err)
 	}
+	if err := d.Set("min_instances", function.MinInstances); err != nil {
+		return fmt.Errorf("Error setting min_instances: %s", err)
+	}
 	if err := d.Set("region", cloudFuncId.Region); err != nil {
 		return fmt.Errorf("Error setting region: %s", err)
 	}
@@ -639,6 +653,11 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("max_instances") {
 		function.MaxInstances = int64(d.Get("max_instances").(int))
 		updateMaskArr = append(updateMaskArr, "maxInstances")
+	}
+
+	if d.HasChange("min_instances") {
+		function.MaxInstances = int64(d.Get("min_instances").(int))
+		updateMaskArr = append(updateMaskArr, "minInstances")
 	}
 
 	if len(updateMaskArr) > 0 {

--- a/google/resource_cloudfunctions_function_test.go
+++ b/google/resource_cloudfunctions_function_test.go
@@ -146,6 +146,8 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(funcResourceName,
 						"max_instances", "10"),
 					resource.TestCheckResourceAttr(funcResourceName,
+						"min_instances", "3"),
+					resource.TestCheckResourceAttr(funcResourceName,
 						"ingress_settings", "ALLOW_INTERNAL_ONLY"),
 					testAccCloudFunctionsFunctionSource(fmt.Sprintf("gs://%s/index.zip", bucketName), &function),
 					testAccCloudFunctionsFunctionTrigger(FUNCTION_TRIGGER_HTTP, &function),
@@ -215,6 +217,8 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 						"timeout", "91"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"max_instances", "15"),
+					resource.TestCheckResourceAttr(funcResourceName,
+						"min_instances", "5"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"ingress_settings", "ALLOW_ALL"),
 					testAccCloudFunctionsFunctionHasLabel("my-label", "my-updated-label-value", &function),
@@ -664,6 +668,7 @@ resource "google_cloudfunctions_function" "function" {
     NEW_ENV_VARIABLE  = "new-build-env-variable-value"
   }
   max_instances = 15
+  min_instances = 5
 }
 `, bucketName, zipFilePath, functionName)
 }
@@ -903,6 +908,7 @@ resource "google_cloudfunctions_function" "function" {
 	TEST_ENV_VARIABLE = "test-env-variable-value"
   }
   max_instances = 10
+  min_instances = 3
   vpc_connector = google_vpc_access_connector.%s.self_link
   vpc_connector_egress_settings = "PRIVATE_RANGES_ONLY"
 

--- a/website/docs/r/cloudfunctions_function.html.markdown
+++ b/website/docs/r/cloudfunctions_function.html.markdown
@@ -150,6 +150,8 @@ Eg. `"nodejs10"`, `"nodejs12"`, `"nodejs14"`, `"python37"`, `"python38"`, `"pyth
 
 * `max_instances` - (Optional) The limit on the maximum number of function instances that may coexist at a given time.
 
+* `min_instances` - (Optional) The limit on the minimum number of function instances that may coexist at a given time.
+
 <a name="nested_event_trigger"></a>The `event_trigger` block supports:
 
 * `event_type` - (Required) The type of event to observe. For example: `"google.storage.object.finalize"`.


### PR DESCRIPTION
Support `min_instances` in Cloud Functions.

https://pkg.go.dev/google.golang.org/api/cloudfunctions/v1#CloudFunction

SVRL-749