### PR TITLE
docs: composer: format list of warnings

### DIFF
--- a/website/docs/r/composer_environment.html.markdown
+++ b/website/docs/r/composer_environment.html.markdown
@@ -36,11 +36,11 @@ will not be able to automatically find or manage many of these underlying resour
   detect some errors in configuration when they are used (e.g. ~40-50 minutes into the creation
   process), and is prone to limited error reporting. If you encounter confusing or uninformative
   errors, please verify your configuration is valid against GCP Cloud Composer before filing bugs
-  against the Terraform provider. * **Environments create Google Cloud Storage buckets that do not get
-  cleaned up automatically** on environment deletion. [More about Composer's use of Cloud
-  Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage). * Please review the [known
-  issues](https://cloud.google.com/composer/docs/known-issues) for Composer if you are having
-  problems.
+  against the Terraform provider.
+* **Environments create Google Cloud Storage buckets that do not get cleaned up automatically** on
+  environment deletion. [More about Composer's use of Cloud Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage).
+* Please review the [known issues](https://cloud.google.com/composer/docs/known-issues) for Composer
+  if you are having problems.
 
 ## Example Usage
 


### PR DESCRIPTION
It appears this block of warnings is a list of warnings that got formatted into
a single block. Adding some newlines breaks it into the bullet points which
helps highlight the GCS bucket limitation and link to known issues.