### PR TITLE
Add `CLOUD_LOGGING_ONLY` as a valid value for the `logging` option

### DIFF
--- a/google/resource_cloudbuild_trigger.go
+++ b/google/resource_cloudbuild_trigger.go
@@ -417,8 +417,8 @@ The elements are of the form "KEY=VALUE" for the environment variable "KEY" bein
 									"logging": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"LOGGING_UNSPECIFIED", "LEGACY", "GCS_ONLY", "STACKDRIVER_ONLY", "NONE", ""}, false),
-										Description:  `Option to specify the logging mode, which determines if and where build logs are stored. Possible values: ["LOGGING_UNSPECIFIED", "LEGACY", "GCS_ONLY", "STACKDRIVER_ONLY", "NONE"]`,
+										ValidateFunc: validation.StringInSlice([]string{"LOGGING_UNSPECIFIED", "LEGACY", "GCS_ONLY", "STACKDRIVER_ONLY", "CLOUD_LOGGING_ONLY", "NONE", ""}, false),
+										Description:  `Option to specify the logging mode, which determines if and where build logs are stored. Possible values: ["LOGGING_UNSPECIFIED", "LEGACY", "GCS_ONLY", "STACKDRIVER_ONLY", "CLOUD_LOGGING_ONLY", "NONE"]`,
 									},
 									"machine_type": {
 										Type:         schema.TypeString,


### PR DESCRIPTION
According to google's API reference this is a valid value.

For more info see: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#Build.LoggingMode

Fixes #10800

## Notes on tests

I added a test for this but I'm not clear if that is the best way to add it - if not and if there are examples of tests which are relevant please point me to them so I can use them instead.

Also I can't get any of the tests for `google_cloudbuild_trigger` to run. I tried to run it like this:

```bash
export GOOGLE_PROJECT=aucampia-test
export GOOGLE_REGION=us-central1
export GOOGLE_ZONE=us-central1-a
export GOOGLE_USE_DEFAULT_CREDENTIALS=1
make testacc TEST=./google TESTARGS='-v -run=^TestAccCloudBuildTrigger_.*$'
```

```console
$ make testacc TEST=./google TESTARGS='-v -run=^TestAccCloudBuildTrigger_.*$'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
go generate  ./...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google -v -v -run=^TestAccCloudBuildTrigger_.*$ -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccCloudBuildTrigger_cloudbuildTriggerFilenameExample
=== PAUSE TestAccCloudBuildTrigger_cloudbuildTriggerFilenameExample
=== RUN   TestAccCloudBuildTrigger_cloudbuildTriggerBuildExample
=== PAUSE TestAccCloudBuildTrigger_cloudbuildTriggerBuildExample
=== RUN   TestAccCloudBuildTrigger_cloudbuildTriggerServiceAccountExample
=== PAUSE TestAccCloudBuildTrigger_cloudbuildTriggerServiceAccountExample
=== RUN   TestAccCloudBuildTrigger_basic
=== PAUSE TestAccCloudBuildTrigger_basic
=== RUN   TestAccCloudBuildTrigger_available_secrets_config
=== PAUSE TestAccCloudBuildTrigger_available_secrets_config
=== RUN   TestAccCloudBuildTrigger_pubsub_config
=== PAUSE TestAccCloudBuildTrigger_pubsub_config
=== RUN   TestAccCloudBuildTrigger_webhook_config
=== PAUSE TestAccCloudBuildTrigger_webhook_config
=== RUN   TestAccCloudBuildTrigger_customizeDiffTimeoutSum
=== PAUSE TestAccCloudBuildTrigger_customizeDiffTimeoutSum
=== RUN   TestAccCloudBuildTrigger_customizeDiffTimeoutFormat
=== PAUSE TestAccCloudBuildTrigger_customizeDiffTimeoutFormat
=== RUN   TestAccCloudBuildTrigger_disable
=== PAUSE TestAccCloudBuildTrigger_disable
=== RUN   TestAccCloudBuildTrigger_fullStep
=== PAUSE TestAccCloudBuildTrigger_fullStep
=== RUN   TestAccCloudBuildTrigger_cloudLogging
=== PAUSE TestAccCloudBuildTrigger_cloudLogging
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerFilenameExample
=== CONT  TestAccCloudBuildTrigger_disable
=== CONT  TestAccCloudBuildTrigger_pubsub_config
=== CONT  TestAccCloudBuildTrigger_customizeDiffTimeoutSum
=== CONT  TestAccCloudBuildTrigger_available_secrets_config
=== CONT  TestAccCloudBuildTrigger_basic
=== CONT  TestAccCloudBuildTrigger_cloudLogging
=== CONT  TestAccCloudBuildTrigger_customizeDiffTimeoutFormat
=== CONT  TestAccCloudBuildTrigger_customizeDiffTimeoutSum
    provider_test.go:274: Step 1/1, expected an error with pattern, no match on: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerFilenameExample
    provider_test.go:274: Step 1/2 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_disable
    provider_test.go:274: Step 1/4 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_cloudLogging
    provider_test.go:274: Step 1/2 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_pubsub_config
    provider_test.go:274: Step 1/4 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_basic
    provider_test.go:274: Step 1/4 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_customizeDiffTimeoutFormat
    provider_test.go:274: Step 1/1, expected an error with pattern, no match on: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_available_secrets_config
    provider_test.go:274: Step 1/4 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_basic
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_basic (0.58s)
=== CONT  TestAccCloudBuildTrigger_webhook_config
=== CONT  TestAccCloudBuildTrigger_cloudLogging
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_cloudLogging (0.59s)
=== CONT  TestAccCloudBuildTrigger_fullStep
=== CONT  TestAccCloudBuildTrigger_customizeDiffTimeoutSum
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_disable
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_disable (0.59s)
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerServiceAccountExample
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerBuildExample
--- FAIL: TestAccCloudBuildTrigger_customizeDiffTimeoutSum (0.59s)
=== CONT  TestAccCloudBuildTrigger_pubsub_config
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_pubsub_config (0.61s)
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerFilenameExample
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_cloudbuildTriggerFilenameExample (0.61s)
=== CONT  TestAccCloudBuildTrigger_customizeDiffTimeoutFormat
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_customizeDiffTimeoutFormat (0.62s)
=== CONT  TestAccCloudBuildTrigger_available_secrets_config
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_available_secrets_config (0.62s)
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerBuildExample
    provider_test.go:274: Step 1/2 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_fullStep
    provider_test.go:274: Step 1/2 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_webhook_config
    provider_test.go:274: Step 1/4 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerServiceAccountExample
    provider_test.go:274: Step 1/2 error: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerBuildExample
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_cloudbuildTriggerBuildExample (0.35s)
=== CONT  TestAccCloudBuildTrigger_fullStep
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_fullStep (0.35s)
=== CONT  TestAccCloudBuildTrigger_webhook_config
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_webhook_config (0.37s)
=== CONT  TestAccCloudBuildTrigger_cloudbuildTriggerServiceAccountExample
    testing_new.go:56: Error retrieving state, there may be dangling resources: unsupported state format version: expected ["0.1" "0.2"], got "1.0"
--- FAIL: TestAccCloudBuildTrigger_cloudbuildTriggerServiceAccountExample (0.36s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-google/google	0.990s
FAIL
make: *** [GNUmakefile:14: testacc] Error 1
20211226T140534 iwana@iwana-pc00.coop.no:~/sw/d/githu
```

Any pointers as to what I'm doing wrong here would be appreciated.