### PR TITLE
Update f1-micro to e2-micro to be part of the "always free" tier

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -74,7 +74,7 @@ Add the following to your config file:
 ```hcl
 resource "google_compute_instance" "vm_instance" {
   name         = "terraform-instance"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
 
   boot_disk {
     initialize_params {
@@ -201,7 +201,7 @@ provider "google" {
 
 resource "google_compute_instance" "vm_instance" {
   name         = "terraform-instance"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
 
   boot_disk {
     initialize_params {


### PR DESCRIPTION
Updating the guide examples to reflect the upgrade to the free-tier VM from f1-micro to e2-micro.