### PR TITLE
Update monitoring_alert_policy.html.markdown

### DIFF
--- a/website/docs/r/monitoring_alert_policy.html.markdown
+++ b/website/docs/r/monitoring_alert_policy.html.markdown
@@ -235,7 +235,9 @@ The following arguments are supported:
   The alignment period for per-time
   series alignment. If present,
   alignmentPeriod must be at least
-  60 seconds. After per-time series
+  60 seconds. The alignment period
+  must be given in multiples of one
+  minute. After per-time series
   alignment, each time series will
   contain data points only on the
   period boundaries. If


### PR DESCRIPTION
- Add hint that alignment_period must be given in 60s increments.
- Language and wording copied from the `terraform apply` error from Google Cloud:

```
googleapi: Error 400: Field alert_policy.conditions[0].condition_threshold.aggregations[0].alignment_period had an invalid value of "{"seconds":450}": alignment period must be in multiples of one minute
```