### PR TITLE
Docs: pull request rename

### DIFF
--- a/website/docs/r/cloudbuild_trigger.html.markdown
+++ b/website/docs/r/cloudbuild_trigger.html.markdown
@@ -324,12 +324,12 @@ The following arguments are supported:
 
 * `pull_request` -
   (Optional)
-  filter to match changes in pull requests.  Specify only one of pullRequest or push.
+  filter to match changes in pull requests.  Specify only one of pull_request or push.
   Structure is [documented below](#nested_pull_request).
 
 * `push` -
   (Optional)
-  filter to match changes in refs, like branches or tags.  Specify only one of pullRequest or push.
+  filter to match changes in refs, like branches or tags.  Specify only one of pull_request or push.
   Structure is [documented below](#nested_push).
 
 

--- a/website/docs/r/cloudbuild_trigger.html.markdown
+++ b/website/docs/r/cloudbuild_trigger.html.markdown
@@ -324,12 +324,12 @@ The following arguments are supported:
 
 * `pull_request` -
   (Optional)
-  filter to match changes in pull requests.  Specify only one of pull_request or push.
+  filter to match changes in pull requests.  Specify only one of `pull_request` or `push`.
   Structure is [documented below](#nested_pull_request).
 
 * `push` -
   (Optional)
-  filter to match changes in refs, like branches or tags.  Specify only one of pull_request or push.
+  filter to match changes in refs, like branches or tags.  Specify only one of `pull_request` or `push`.
   Structure is [documented below](#nested_push).
 
 


### PR DESCRIPTION
In documentation for `github` block ([here](https://github.com/hashicorp/terraform-provider-google/blob/master/website/docs/r/cloudbuild_trigger.html.markdown#argument-reference
)), "pull_request" is referred to as "pullRequest". This PR fixes it. It also adds backticks around `pull_request` and `push`.
