### PR TITLE
Docs(logging_project_sink): Replace google_project_iam_binding with google_project_iam_member 

### DIFF
--- a/website/docs/r/logging_project_sink.html.markdown
+++ b/website/docs/r/logging_project_sink.html.markdown
@@ -81,13 +81,11 @@ resource "google_logging_project_sink" "instance-sink" {
 }
 
 # Because our sink uses a unique_writer, we must grant that writer access to the bucket.
-resource "google_project_iam_binding" "log-writer" {
+resource "google_project_iam_member" "log-writer" {
   project = "your-project-id"
   role = "roles/storage.objectCreator"
 
-  members = [
-    google_logging_project_sink.instance-sink.writer_identity,
-  ]
+  member = google_logging_project_sink.instance-sink.writer_identity
 }
 ```
 


### PR DESCRIPTION
In the documentation for logging_project_sink resource, the example uses `google_project_iam_binding` to add a permission to write the storage. We should use `google_project_iam_member` in this example, because using the `google_project_iam_binding` removes all the bindings to the specified role that are not present in `members`. `google_project_iam_member` just adds a member to the role.

I just copy-pasted the example without thinking too much, and surprised to find the role settings in my project modified in an unexpected way. Of course this behavior is documented in the `google_project_iam_binding`, but I don't want anyone else to experience the same.