### PR TITLE
Update google_sql_database_instance documentation

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -258,8 +258,7 @@ The optional `settings.database_flags` sublist supports:
 
 The optional `settings.backup_configuration` subblock supports:
 
-* `binary_log_enabled` - (Optional) True if binary logging is enabled. If
-    `settings.backup_configuration.enabled` is false, this must be as well.
+* `binary_log_enabled` - (Optional) True if binary logging is enabled.
     Cannot be used with Postgres.
 
 * `enabled` - (Optional) True if backup configuration is enabled.


### PR DESCRIPTION
`settings.backup_configuration.binary_log_enabled` may be true even if `settings.backup_configuration.enabled` is false.

This behaviour as changed in https://github.com/GoogleCloudPlatform/magic-modules/pull/4907

## Related Material
https://cloud.google.com/sql/docs/mysql/replication#bin-log-replica
https://github.com/GoogleCloudPlatform/magic-modules/pull/4907