### PR TITLE
Add support for filestore csi driver in GKE ressource

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -369,6 +369,10 @@ subnetwork in which the cluster's instances are launched.
 
 * `cloudrun_config` - (Optional). Structure is [documented below](#nested_cloudrun_config).
 
+* `gcp_filestore_csi_driver_config` - (Optional) The status of the Filestore CSI driver addon, 
+    which allows the usage of filestore instance as volumes.
+    It is disbaled by default; set `enabled = true` to enable.
+
 * `istio_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     Structure is [documented below](#nested_istio_config).
 


### PR DESCRIPTION
This PR enables the use of the Filestore CSI Driver as an addon in a GKE cluster - it resolves #10524.

_Note: if i understood the contribution guidelines correctly, the container cluster ressource is not yet manged with magic modules and therefore the correct way for updates is a PR here which is then upstreamed into the magic modules hand-written directory. If i'm mistaken, i'd be thankful for a pointer to the "correct" project to resolve the issue._