### PR TITLE
Document default value of `sql_database_instance.availability_type`

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -233,7 +233,7 @@ The `settings` block supports:
 * `activation_policy` - (Optional) This specifies when the instance should be
     active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
 
-* `availability_type` - (Optional) The availability type of the Cloud SQL
+* `availability_type` - (Optional, Default: `ZONAL`) The availability type of the Cloud SQL
 instance, high availability (`REGIONAL`) or single zone (`ZONAL`).' For MySQL
 instances, ensure that `settings.backup_configuration.enabled` and
 `settings.backup_configuration.binary_log_enabled` are both set to `true`.


### PR DESCRIPTION
Documents default value of `sql_database_instance.availability_type`

https://github.com/hashicorp/terraform-provider-google/blob/4e1cf4615d1e473453fa5f40f206188341061340/google/resource_sql_database_instance.go#L147-L150