### PR TITLE
Fixes #11078 - Documentation error in redis_instance documentation

### DIFF
--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -475,7 +475,7 @@ In addition to the arguments listed above, the following computed attributes are
   Serial number, as extracted from the certificate.
 
 * `cert` -
-  Serial number, as extracted from the certificate.
+  The certificate data in PEM format.
 
 * `create_time` -
   The time when the certificate was created.


### PR DESCRIPTION
This PR fixes a documentation error in the redis_instance documentation as described in #11078 (Basically a copy-paste error/typo fix)