### PR TITLE
Comment on google_service_networking_connection

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -123,7 +123,7 @@ resource "google_compute_global_address" "private_ip_address" {
   network       = google_compute_network.private_network.id
 }
 
-# When adding this resource to an existent VPC network, the `google_sql_database_instance` 
+# When adding this resource to an existent VPC network (i.e: with subnetworks already configured), the `google_sql_database_instance` 
 # doesn't turn reachable through its private IP until an option called `Export custom routes` gets manually 
 # enabled through the GCP console
 resource "google_service_networking_connection" "private_vpc_connection" {

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -124,7 +124,7 @@ resource "google_compute_global_address" "private_ip_address" {
 }
 
 # When adding this resource to an existent VPC network, the `google_sql_database_instance` 
-# doesn't isn't reachable through its private IP until an option called `Export custom routes` gets manually 
+# doesn't turn reachable through its private IP until an option called `Export custom routes` gets manually 
 # enabled through the GCP console
 resource "google_service_networking_connection" "private_vpc_connection" {
   provider = google-beta

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -124,7 +124,7 @@ resource "google_compute_global_address" "private_ip_address" {
 }
 
 # When adding this resource to an existent VPC network, the `google_sql_database_instance` 
-# doesn't turn available until an option called `Export custom routes` gets manually 
+# doesn't isn't reachable through its private IP until an option called `Export custom routes` gets manually 
 # enabled through the GCP console
 resource "google_service_networking_connection" "private_vpc_connection" {
   provider = google-beta

--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -123,6 +123,9 @@ resource "google_compute_global_address" "private_ip_address" {
   network       = google_compute_network.private_network.id
 }
 
+# When adding this resource to an existent VPC network, the `google_sql_database_instance` 
+# doesn't turn available until an option called `Export custom routes` gets manually 
+# enabled through the GCP console
 resource "google_service_networking_connection" "private_vpc_connection" {
   provider = google-beta
 


### PR DESCRIPTION
**Why is this pull request necessary**?
Because I've struggled a lot provisioning a new private CloudSQL instance just following this documentation and I think this information might be helpful.

**Notes**:
The option `Export custom routes` isn't yet available for this provider. Hence I thought the commentary could be useful for anyone facing painful connectivity problems as I did.

**References**:
https://github.com/hashicorp/terraform-provider-google/issues/8396
