### PR TITLE
Clarify project ID requirement in google_storage_bucket docs

### DIFF
--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -76,8 +76,7 @@ The following arguments are supported:
 
 * `location` - (Required) The [GCS location](https://cloud.google.com/storage/docs/bucket-locations)
 
-* `project` - (Optional) The ID of the project in which the resource belongs. If it
-    is not provided, the provider project is used.
+* `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided and the provider has been configured with a project, that project is used. If neither are defined, an error is returned.
 
 * `storage_class` - (Optional, Default: 'STANDARD') The [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of the new bucket. Supported values include: `STANDARD`, `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`.
 


### PR DESCRIPTION
I had a situation where the provider was not configured with a project ID and I also didn't specify the project in the resource configuration. Terraform failed to apply the update and the API error said that the project ID was a required field. It's optional in Terraform but only because it falls back to using the provider's configured project ID instead. When that does not exist, the field is omitted from the API call and it fails. From Terraform's perspective, a developer could omit the `project` parameter in the resource configuration but not in the API call, which is why I'm proposing to clarify it in this PR.