### PR TITLE
cloud function: keep source archive object fragment

### DIFF
--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -597,7 +597,7 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 		bucket := sourceURL.Host
-		object := strings.TrimLeft(sourceURL.Path, "/")
+		object := strings.TrimLeft(sourceURL.Path+"#"+sourceURL.Fragment, "/")
 		if err := d.Set("source_archive_bucket", bucket); err != nil {
 			return fmt.Errorf("Error setting source_archive_bucket: %s", err)
 		}


### PR DESCRIPTION
This allows to use "source.zip#<md5sum>" and not have the function
updated even when source has not changed