### PR TITLE
docs: `name` in `secret_manager_secret` uses project number

### DIFF
--- a/website/docs/r/secret_manager_secret.html.markdown
+++ b/website/docs/r/secret_manager_secret.html.markdown
@@ -177,7 +177,7 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `name` -
   The resource name of the Secret. Format:
-  `projects/{{project}}/secrets/{{secret_id}}`
+  `projects/{{project_number}}/secrets/{{secret_id}}`
 
 * `create_time` -
   The time at which the Secret was created.


### PR DESCRIPTION
The `secret_manager_secret` attribute `name` format does not use the provided `{{project}}` value, but rather always resolves to the project *number*, which often causes plans that appear to be out of date yet re-application changes nothing. E.g., this is the underlying problem in https://github.com/hashicorp/terraform-provider-google/issues/5963.

This PR calls out this behavior explicitly in the docs, so that at least people can see the difference vs `id` and choose accordingly.