### PR TITLE
docs: Additional examples of import with condition for IAM binding resources

### DIFF
--- a/website/docs/r/google_folder_iam.html.markdown
+++ b/website/docs/r/google_folder_iam.html.markdown
@@ -241,3 +241,6 @@ terraform import google_folder_iam_audit_config.my_folder "folder foo.googleapis
 
 -> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `organizations/{{org_id}}/roles/{{role_id}}`.
+-> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure
+ to include the title of condition, e.g. `terraform import google_folder_iam_binding.my_folder "folder roles/{{role_id}} condition-title"`
+

--- a/website/docs/r/google_organization_iam.html.markdown
+++ b/website/docs/r/google_organization_iam.html.markdown
@@ -246,3 +246,6 @@ terraform import google_organization_iam_audit_config.my_organization "your-orga
 
 -> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `organizations/{{org_id}}/roles/{{role_id}}`.
+ 
+-> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure
+ to include the title of condition, e.g. `terraform import google_organization_iam_binding.my_organization "your-org-id roles/viewer condition-title"`

--- a/website/docs/r/google_organization_iam.html.markdown
+++ b/website/docs/r/google_organization_iam.html.markdown
@@ -248,4 +248,4 @@ terraform import google_organization_iam_audit_config.my_organization "your-orga
  full name of the custom role, e.g. `organizations/{{org_id}}/roles/{{role_id}}`.
  
 -> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure
- to include the title of condition, e.g. `terraform import google_organization_iam_binding.my_organization "your-org-id roles/viewer condition-title"`
+ to include the title of condition, e.g. `terraform import google_organization_iam_binding.my_organization "your-org-id roles/{{role_id}} condition-title"`

--- a/website/docs/r/google_project_iam.html.markdown
+++ b/website/docs/r/google_project_iam.html.markdown
@@ -241,3 +241,6 @@ terraform import google_project_iam_audit_config.my_project "your-project-id foo
 
 -> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
+-> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure
+ to include the title of condition, e.g. `terraform import google_project_iam_binding.my_project "{{your-project-id}} roles/{{role_id}} condition-title"`
+


### PR DESCRIPTION
Fixed the issue https://github.com/hashicorp/terraform-provider-google/issues/11338 by providing examples for importing:

- google_organization_iam_binding
- google_folder_iam_binding
- google_project_iam_binding

with condition block