### PR TITLE
Update resource_compute_subnetwork.go

### DIFF
--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -424,6 +424,7 @@ func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	} else if v, ok := d.GetOkExists("log_config"); ok || !reflect.DeepEqual(v, logConfigProp) {
 		obj["logConfig"] = logConfigProp
+		obj["enableFlowLogs"] = true
 	}
 	stackTypeProp, err := expandComputeSubnetworkStackType(d.Get("stack_type"), d, config)
 	if err != nil {


### PR DESCRIPTION
Fix for #11265 to make policy constraint play nicely when `log_config` (Flow logs) is enabled