### PR TITLE
Remove insightsPostgresOnlyCustomizeDiff function

### DIFF
--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -103,7 +103,6 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 			customdiff.ForceNewIfChange("settings.0.disk_size", isDiskShrinkage),
 			privateNetworkCustomizeDiff,
 			pitrPostgresOnlyCustomizeDiff,
-			insightsPostgresOnlyCustomizeDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -721,15 +720,6 @@ func pitrPostgresOnlyCustomizeDiff(_ context.Context, diff *schema.ResourceDiff,
 	dbVersion := diff.Get("database_version").(string)
 	if pitr && !strings.Contains(dbVersion, "POSTGRES") {
 		return fmt.Errorf("point_in_time_recovery_enabled is only available for Postgres. You may want to consider using binary_log_enabled instead.")
-	}
-	return nil
-}
-
-func insightsPostgresOnlyCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-	insights := diff.Get("settings.0.insights_config.0.query_insights_enabled").(bool)
-	dbVersion := diff.Get("database_version").(string)
-	if insights && !strings.Contains(dbVersion, "POSTGRES") {
-		return fmt.Errorf("query_insights_enabled is only available for Postgres now.")
 	}
 	return nil
 }


### PR DESCRIPTION
Hi! 👋 We've recently enabled Cloud SQL Insights on our MySQL instances, but unfortunately we're no longer able to run `plan` or `apply` in the Terraform environments which manage the instances because the `insightsPostgresOnlyCustomizeDiff` function that is used by the `google_sql_database_instance` resource enforces that the Database that Query Insights is enabled on is a Postgres database. Would it make sense to remove this function now that the feature is available for MySQL?

P.S. Thanks for the awesome provider! 😄 