### PR TITLE
Prevent leaking credentials to the console if malformed JSON is given

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -1525,7 +1525,7 @@ func validateCredentials(v interface{}, k string) (warnings []string, errors []e
 	}
 	if _, err := googleoauth.CredentialsFromJSON(context.Background(), []byte(creds)); err != nil {
 		errors = append(errors,
-			fmt.Errorf("JSON credentials in %q are not valid: %s", creds, err))
+			fmt.Errorf("JSON credentials are not valid: %s", err))
 	}
 
 	return


### PR DESCRIPTION
If the JSON credentials are unable to be properly parsed, the error
message will output those very credentials _in plain text_ to the
console. This is obviously a serious security concern for any CI systems
running Terraform that may produce this error.

There's really no reason to output the "this string is what we can't
parse" in the error message. The `err` is sufficient enough. The user
can inspect their own JSON credentials file.

I'm sure this can be done a better way, maybe by outputting it to the
debug logs; however, this is a quick and easy fix to remove the security
concern from this issue immediately while a better solution can be
found.

Closes https://github.com/hashicorp/terraform-provider-google/issues/11598