### PR TITLE
Consolidating BQ reservation resources to one section in docs.

### DIFF
--- a/website/docs/r/bigquery_reservation_assignment.html.markdown
+++ b/website/docs/r/bigquery_reservation_assignment.html.markdown
@@ -13,7 +13,7 @@
 #     are required, please file an issue at https:#github.com/hashicorp/terraform-provider-google/issues/new/choose
 #
 # ----------------------------------------------------------------------------
-subcategory: "BigqueryReservation"
+subcategory: "BigQuery Reservation"
 layout: "google"
 page_title: "Google: google_bigquery_reservation_assignment"
 sidebar_current: "docs-google-bigquery-reservation-assignment"

--- a/website/google.erb
+++ b/website/google.erb
@@ -414,19 +414,7 @@
           <li>
           <a href="/docs/providers/google/r/bigquery_reservation.html">google_bigquery_reservation</a>
           </li>
-  
-        </ul>
-      </li>
-    </ul>
-    </li>
 
-    <li>
-    <a href="#">BigqueryReservation</a>
-    <ul class="nav">
-      <li>
-        <a href="#">Resources</a>
-        <ul class="nav nav-auto-expand">
-  
           <li>
           <a href="/docs/providers/google/r/bigquery_reservation_assignment.html">google_bigquery_reservation_assignment</a>
           </li>


### PR DESCRIPTION
Aggregates the 2 resources so they show under the normalized name "BigQuery Reservation" in the docs.

<img width="501" alt="Screen Shot 2022-05-02 at 9 38 22 AM" src="https://user-images.githubusercontent.com/46936562/166243131-b3aaf31a-2375-4aee-bf57-4a4dd08f09d7.png">
