### PR TITLE
Fix #10620: Update documentation for kms_crypto_key

### DIFF
--- a/website/docs/r/kms_crypto_key.html.markdown
+++ b/website/docs/r/kms_crypto_key.html.markdown
@@ -171,10 +171,9 @@ This resource provides the following
 
 
 CryptoKey can be imported using any of these accepted formats:
-
 ```
-$ terraform import google_kms_crypto_key.default {{key_ring}}/cryptoKeys/{{name}}
-$ terraform import google_kms_crypto_key.default {{key_ring}}/{{name}}
+$ terraform import google_kms_crypto_key.default {projectId}/{locationId}/{keyringName}/{cryptoKeyName}
+$ terraform import google_kms_crypto_key.default {locationId}/{keyringName}/{cryptoKeyName}
 ```
 
 ## User Project Overrides


### PR DESCRIPTION
Documentation claims you can import cryptoKeys using either `{{key_ring}}/cryptoKeys/{{name}}` or `{{key_ring}}/{{name}}`, but that results in an error.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10620

This updates the documentation to reflect accurate information.