### PR TITLE
remove protocol versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   contents: write
 
-env:
-  PROTOCOL_VERSION: "5.0"
-  PROTOCOL_VERSIONS: "5.0"
-
 jobs:
   go-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
we're going to hardcode the protocol version into goreleaser instead