### PR TITLE
Add PSC Connection ID

### DIFF
--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -146,6 +146,12 @@ func resourceComputeGlobalForwardingRule() *schema.Resource {
 				Description: "Used internally during label updates.",
 			},
 
+			"psc_connection_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "[Output Only] Server-defined Private Service Connection ID for the resource.",
+			},
+
 			"self_link": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -274,6 +280,7 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 		Labels:              checkStringMap(d.Get("labels")),
 		LoadBalancingScheme: compute.ForwardingRuleLoadBalancingSchemeEnumRef(d.Get("load_balancing_scheme").(string)),
 		MetadataFilter:      expandComputeGlobalForwardingRuleMetadataFilterArray(d.Get("metadata_filters")),
+		PscConnectionId:     dcl.String(d.Get("psc_connection_id").(string)),
 		Network:             dcl.StringOrNil(d.Get("network").(string)),
 		PortRange:           dcl.String(d.Get("port_range").(string)),
 		Project:             dcl.String(project),
@@ -333,6 +340,9 @@ func resourceComputeGlobalForwardingRuleRead(d *schema.ResourceData, meta interf
 	}
 	if err = d.Set("port_range", res.PortRange); err != nil {
 		return fmt.Errorf("error setting port_range in state: %s", err)
+	}
+	if err = d.Set("psc_connection_id", res.PscConnectionId); err != nil {
+		return fmt.Errorf("error setting psc_connection_id in state: %s", err)
 	}
 	if err = d.Set("project", res.Project); err != nil {
 		return fmt.Errorf("error setting project in state: %s", err)


### PR DESCRIPTION
This is my first contribution here so just a heads up if I forget anything.

Adds `psc_connection_id` as an output of the `global_forwarding_rule`.
Issue: https://github.com/hashicorp/terraform-provider-google/issues/10588

Requires: https://github.com/GoogleCloudPlatform/declarative-resource-client-library/pull/11