### PR TITLE
Add documentation note about iam permissions for workload identity pool

### DIFF
--- a/website/docs/r/iam_workload_identity_pool.html.markdown
+++ b/website/docs/r/iam_workload_identity_pool.html.markdown
@@ -28,6 +28,8 @@ grant these identities access to Google Cloud resources.
 ~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
 
+**IAM Requirements Note:** The following resource requires the Beta IAM role "roles/iam.workloadIdentityPoolAdmin" in order to succeed. Owner and Editor roles do not include the necessary permissions. 
+
 To get more information about WorkloadIdentityPool, see:
 
 * [API documentation](https://cloud.google.com/iam/docs/reference/rest/v1beta/projects.locations.workloadIdentityPools)


### PR DESCRIPTION
Quick documentation note that resolves issue #11789 