### PR TITLE
The regular expression in doc should be presented as it is

### DIFF
--- a/google/resource_apikeys_key.go
+++ b/google/resource_apikeys_key.go
@@ -49,7 +49,7 @@ func resourceApikeysKey() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The resource name of the key. The name must be unique within the project, must conform with RFC-1034, is restricted to lower-cased letters, and has a maximum length of 63 characters. In another word, the name must match the regular expression: [a-z]([a-z0-9-]{0,61}[a-z0-9])?.",
+				Description: "The resource name of the key. The name must be unique within the project, must conform with RFC-1034, is restricted to lower-cased letters, and has a maximum length of 63 characters. In another word, the name must match the regular expression: `[a-z]([a-z0-9-]{0,61}[a-z0-9])?` .",
 			},
 
 			"display_name": {


### PR DESCRIPTION
The regular expression in doc `[a-z]([a-z0-9-]{0,61}[a-z0-9])?` should be presented as it is, but it is parsed as a link of markdown format.

example:
![スクリーンショット 2022-06-16 15 01 36](https://user-images.githubusercontent.com/6166778/174002183-32dd0ef2-a510-4cf3-b613-304d7c453e34.png)

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/apikeys_key#name