### PR TITLE
Remove lint from GH Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,5 +32,4 @@ jobs:
     - name: Test
       run: |
         make docscheck
-        make lint
         make test


### PR DESCRIPTION
This doesn't seem to work right, and the Magician's still does- leave it in place for that, but otherwise stop running it. The signal we get from direct runs is low anyways.