### PR TITLE
add support for MatchesPrefix and MatchesSuffix in condition of lifecycle rule (google_storage_bucket)

### DIFF
--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -1226,7 +1226,7 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 		for _, v := range suffixes {
 			transformedSuffixes = append(transformedSuffixes, v.(string))
 		}
-		transformed.MatchesSuffixes = transformedSuffixes
+		transformed.MatchesSuffix = transformedSuffixes
 	}
 
 	return transformed, nil

--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -207,6 +207,18 @@ func resourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Description: `Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.`,
 									},
+									"matches_prefix": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `One or more matching name prefixes to satisfy this condition.`,
+									},
+									"matches_suffix": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `One or more matching name suffixes to satisfy this condition.`,
+									},
 								},
 							},
 							Description: `The Lifecycle Rule's condition configuration.`,
@@ -987,6 +999,8 @@ func flattenBucketLifecycleRuleCondition(condition *storage.BucketLifecycleRuleC
 		"days_since_custom_time":     int(condition.DaysSinceCustomTime),
 		"days_since_noncurrent_time": int(condition.DaysSinceNoncurrentTime),
 		"noncurrent_time_before":     condition.NoncurrentTimeBefore,
+		"matches_prefix":             convertStringArrToInterface(condition.MatchesPrefix),
+		"matches_suffix":             convertStringArrToInterface(condition.MatchesSuffix),
 	}
 	if condition.IsLive == nil {
 		ruleCondition["with_state"] = "ANY"
@@ -1196,6 +1210,25 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 		transformed.NoncurrentTimeBefore = v.(string)
 	}
 
+	if v, ok := condition["matches_prefix"]; ok {
+		prefixes := v.([]interface{})
+		transformedPrefixes := make([]string, 0, len(prefixes))
+
+		for _, v := range prefixes {
+			transformedPrefixes = append(transformedPrefixes, v.(string))
+		}
+		transformed.MatchesPrefix = transformedPrefixes
+	}
+	if v, ok := condition["matches_suffix"]; ok {
+		suffixes := v.([]interface{})
+		transformedSuffixes := make([]string, 0, len(suffixes))
+
+		for _, v := range suffixes {
+			transformedSuffixes = append(transformedSuffixes, v.(string))
+		}
+		transformed.MatchesSuffixes = transformedSuffixes
+	}
+
 	return transformed, nil
 }
 
@@ -1259,6 +1292,19 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 
 	if v, ok := m["num_newer_versions"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	if v, ok := m["matches_prefix"]; ok {
+		matches_prefixes := v.([]interface{})
+		for _, matches_prefix := range matches_prefixes {
+			buf.WriteString(fmt.Sprintf("%s-", matches_prefix))
+		}
+	}
+	if v, ok := m["matches_suffix"]; ok {
+		matches_suffixes := v.([]interface{})
+		for _, matches_suffix := range matches_suffixes {
+			buf.WriteString(fmt.Sprintf("%s-", matches_suffix))
+		}
 	}
 
 	return hashcode(buf.String())

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -1356,6 +1356,23 @@ resource "google_storage_bucket" "bucket" {
       with_state = "ARCHIVED"
     }
   }
+  lifecycle_rule {
+    action {
+      type          = "Delete"
+    }
+    condition {
+      matches_prefix = ["test"]
+      age                   = 2
+    }
+  lifecycle_rule {
+    action {
+      type          = "Delete"
+    }
+	condition {
+      matches_suffix = ["test"]
+      age            = 2
+	}
+  }
 }
 `, bucketName)
 }
@@ -1420,6 +1437,23 @@ resource "google_storage_bucket" "bucket" {
     condition {
       with_state = "ARCHIVED"
     }
+  }
+  lifecycle_rule {
+    action {
+      type          = "Delete"
+    }
+    condition {
+      matches_prefix = ["test"]
+      age                   = 2
+    }
+  lifecycle_rule {
+    action {
+      type          = "Delete"
+    }
+	condition {
+      matches_suffix = ["test"]
+      age            = 2
+	}
   }
 }
 `, bucketName)


### PR DESCRIPTION
Adds Support for [MatchesPrefix and MatchesSuffix](https://cloud.google.com/storage/docs/lifecycle#matchesprefix-suffix) like requested here: https://github.com/hashicorp/terraform-provider-google/issues/11990