### PR TITLE
Certificate Manager: Update selfmanaged  API fields

### DIFF
--- a/google/resource_certificate_manager_certificate.go
+++ b/google/resource_certificate_manager_certificate.go
@@ -461,9 +461,9 @@ func flattenCertificateManagerCertificateSelfManaged(v interface{}, d *schema.Re
 	}
 	transformed := make(map[string]interface{})
 	transformed["certificate_pem"] =
-		flattenCertificateManagerCertificateSelfManagedCertificatePem(original["certificatePem"], d, config)
+		flattenCertificateManagerCertificateSelfManagedCertificatePem(original["pemCertificate"], d, config)
 	transformed["private_key_pem"] =
-		flattenCertificateManagerCertificateSelfManagedPrivateKeyPem(original["privateKeyPem"], d, config)
+		flattenCertificateManagerCertificateSelfManagedPrivateKeyPem(original["pemPrivateKey"], d, config)
 	return []interface{}{transformed}
 }
 func flattenCertificateManagerCertificateSelfManagedCertificatePem(v interface{}, d *schema.ResourceData, config *Config) interface{} {
@@ -535,14 +535,14 @@ func expandCertificateManagerCertificateSelfManaged(v interface{}, d TerraformRe
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedCertificatePem); val.IsValid() && !isEmptyValue(val) {
-		transformed["certificatePem"] = transformedCertificatePem
+		transformed["pemCertificate"] = transformedCertificatePem
 	}
 
 	transformedPrivateKeyPem, err := expandCertificateManagerCertificateSelfManagedPrivateKeyPem(original["private_key_pem"], d, config)
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedPrivateKeyPem); val.IsValid() && !isEmptyValue(val) {
-		transformed["privateKeyPem"] = transformedPrivateKeyPem
+		transformed["pemPrivateKey"] = transformedPrivateKeyPem
 	}
 
 	return transformed, nil


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/12091

Downstream GCP API fields for self-managed certificates are `pemCertificate` and  `pemPrivateKey `.  However the existing code refers to them as `certificatePem` and `privatekeyPem` [1].

Prior to change I was recieving;

<img width="944" alt="Screen Shot 2022-07-14 at 10 15 14 AM" src="https://user-images.githubusercontent.com/11538902/179003882-3809253e-671f-43f2-99ac-6d66d20061d9.png">

Post change the certficiate was created succesfully 
<img width="942" alt="Screen Shot 2022-07-14 at 10 17 33 AM" src="https://user-images.githubusercontent.com/11538902/179004046-8f2a0c1e-bc58-4fac-a89d-95b48a29a37b.png">

```sh
gcloud certificate-manager certificates list
NAME                   SUBJECT_ALTERNATIVE_NAMES  DESCRIPTION       SCOPE       EXPIRE_TIME                 CREATE_TIME                 UPDATE_TIME
testcme-alekssaul-com  testcme.alekssaul.com      The default cert  EDGE_CACHE  2022-10-11 21:59:28 +00:00  2022-07-14 14:09:15 +00:00  2022-07-14 14:09:16 +00:00
```



[1] https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.certificates#SelfManagedCertificate