### PR TITLE
Learn Tutorials referencing TF Guides revealed inconsistency.

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -29,13 +29,13 @@ want to include the following configuration:
 
 ```hcl
 provider "google" {
-  project = "{{YOUR GCP PROJECT}}"
+  project = "my-project-id"
   region  = "us-central1"
   zone    = "us-central1-c"
 }
 ```
 
-* The `project` field should be your personal project id. The `project`
+* The `project` field should be your personal Project ID. This can be found under Project info on your GCP Dashboard. The `project`
 indicates the default GCP project all of your resources will be created in.
 Most Terraform resources will have a `project` field.
 * The `region` and `zone` are [locations](https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources)


### PR DESCRIPTION
It was noticed during a Vault Learn Tutorial that required GCP provider setup using Terraform revealed inconsistent examples between the GCP Registry provider pages. Most examples use "my-project-id", whereas "{{YOUR GCP PROJECT}}" caused users to test with their Project name instead of the required ID. Furthermore, new users benefited from some instruction on where to find the ID, so that was added as well. Thank you in advance.