### PR TITLE
docs: vpc-access-connector refd via id not name

### DIFF
--- a/website/docs/r/vpc_access_connector.html.markdown
+++ b/website/docs/r/vpc_access_connector.html.markdown
@@ -153,7 +153,7 @@ resource "google_cloud_run_service" "gcr_service" {
         # Limit scale up to prevent any cost blow outs!
         "autoscaling.knative.dev/maxScale" = "5"
         # Use the VPC Connector
-        "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.connector.name
+        "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.connector.id
         # all egress from the service should go through the VPC Connector
         "run.googleapis.com/vpc-access-egress" = "all-traffic"
       }


### PR DESCRIPTION
The metadata annotations for a cloud run service should refer to the vpc-access-connector via the id not by the name.