### PR TITLE
Add ability to import Dataflow jobs

### DIFF
--- a/.changelog/12214.txt
+++ b/.changelog/12214.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dataflow: added the ability to import a dataflow job by job id
+```

--- a/google/resource_dataflow_job.go
+++ b/google/resource_dataflow_job.go
@@ -59,6 +59,9 @@ func resourceDataflowJob() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			resourceDataflowJobTypeCustomizeDiff,
 		),
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/website/docs/r/dataflow_job.html.markdown
+++ b/website/docs/r/dataflow_job.html.markdown
@@ -129,4 +129,8 @@ The following arguments are supported:
 
 ## Import
 
-This resource does not support import.
+Dataflow jobs can be imported using the job `id` e.g.
+
+```
+$ terraform import google_dataflow_job.example 2022-07-31_06_25_42-11926927532632678660
+```


### PR DESCRIPTION
This PR closes #12088 and makes it possible to import Dataflow jobs using the [state importer function](https://www.terraform.io/plugin/sdkv2/resources/import#importer-state-function).

Dataflow jobs can be imported using their job ID.

```
bruno@pop-os ~/D/t/12088 [1]> terraform import google_dataflow_job.default 2022-07-31_06_25_42-11926927532632678660                                                                                                           (base) 
google_dataflow_job.default: Importing from ID "2022-07-31_06_25_42-11926927532632678660"...
google_dataflow_job.default: Import prepared!
  Prepared google_dataflow_job for import
google_dataflow_job.default: Refreshing state... [id=2022-07-31_06_25_42-11926927532632678660]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```