### PR TITLE
Run `go mod download` instead of `go get`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go get
+        go mod download
         make tools
 
     - name: Build


### PR DESCRIPTION
Running `go get` during builds means that we're able to pull new dependencies not in the `go.sum` file during builds, allowing the two to drift. Other tooling such as TeamCity doesn't do so, causing failures in later build stages.

In theory, this will pull only the versions represented in `go.sum` and move failures to the appropriate place.