### PR TITLE
Remove metalinter, slightly rework build+test rule

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,11 +23,13 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go get
-        make tools
+        go mod download
 
     - name: Build
-      run: go build
+      run: |
+        make lint
+        make generate
+        go build
 
     - name: Test
       run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,13 +5,13 @@ DIR_NAME=google
 
 default: build
 
-build: fmtcheck generate
+build: lint generate
 	go install
 
-test: fmtcheck generate
+test: lint generate
 	go test $(TESTARGS) -timeout=30s $(TEST)
 
-testacc: fmtcheck generate
+testacc: generate
 	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
 
 fmt:
@@ -20,18 +20,12 @@ fmt:
 
 # Currently required by tf-deploy compile
 fmtcheck:
-	@echo "==> Checking source code against gofmt..."
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
-lint:
-	@echo "==> Checking source code against linters..."
-	@GOGC=off golangci-lint run -v ./$(DIR_NAME)
+vet:
+	go vet
 
-tools:
-	@echo "==> installing required tooling..."
-	go install github.com/client9/misspell/cmd/misspell@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
+lint: fmtcheck vet
 
 generate:
 	go generate  ./...
@@ -54,4 +48,4 @@ endif
 docscheck:
 	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
 
-.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test docscheck generate
+.PHONY: build test testacc fmt fmtcheck vet lint test-compile website website-test docscheck generate


### PR DESCRIPTION
The metalinter we're using, golangci-lint, is causing more trouble than it's worth in terms of timeout issues. Remove it, and call `go vet` directly since we're not calling that through a metalinter anymore. We removed it from this repo on https://github.com/hashicorp/terraform-provider-google/pull/11968 anyways, so this just gets rid of the target the Magician used.

I've gotta remove the Magician bits first, since it'll complain if they go away too soon. So this will stay around for a bit once approved.