### PR TITLE
google_dns_managed_zone: add zone ID attribute

### DIFF
--- a/google/data_source_dns_managed_zone.go
+++ b/google/data_source_dns_managed_zone.go
@@ -26,6 +26,12 @@ func dataSourceDnsManagedZone() *schema.Resource {
 				Computed: true,
 			},
 
+			"managed_zone_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Unique identifier for the resource; defined by the server.`,
+			},
+
 			"name_servers": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -69,17 +75,20 @@ func dataSourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) erro
 		return handleNotFoundError(err, d, fmt.Sprintf("dataSourceDnsManagedZone %q", name))
 	}
 
-	if err := d.Set("name_servers", zone.NameServers); err != nil {
-		return fmt.Errorf("Error setting name_servers: %s", err)
+	if err := d.Set("dns_name", zone.DnsName); err != nil {
+		return fmt.Errorf("Error setting dns_name: %s", err)
 	}
 	if err := d.Set("name", zone.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("dns_name", zone.DnsName); err != nil {
-		return fmt.Errorf("Error setting dns_name: %s", err)
-	}
 	if err := d.Set("description", zone.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("managed_zone_id", zone.Id); err != nil {
+		return fmt.Errorf("Error setting managed_zone_id: %s", err)
+	}
+	if err := d.Set("name_servers", zone.NameServers); err != nil {
+		return fmt.Errorf("Error setting name_servers: %s", err)
 	}
 	if err := d.Set("visibility", zone.Visibility); err != nil {
 		return fmt.Errorf("Error setting visibility: %s", err)

--- a/google/data_source_dns_managed_zone_test.go
+++ b/google/data_source_dns_managed_zone_test.go
@@ -27,7 +27,6 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 						"forwarding_config.#":         {},
 						"force_destroy":               {},
 						"labels.#":                    {},
-						"managed_zone_id":             {},
 						"creation_time":               {},
 					},
 				),


### PR DESCRIPTION
In [the data source for DNS managed zones](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone), include a new "managed_zone_id" attribute reporting the zone's ID, matching the corresponding [`google_dns_managed_zone` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone)'s [output attribute with the same name](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone#managed_zone_id).

While we're here, revise the order in which we transcribe the fields from the fetched object to the data source's attributes to match the declaration order in the schema.

Fixes #7128.