### PR TITLE
Allow subordinate CA data sources in all states

### DIFF
--- a/google/data_source_certificate_authority.go
+++ b/google/data_source_certificate_authority.go
@@ -43,8 +43,8 @@ func dataSourcePrivatecaCertificateAuthorityRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	// pem_csr is only applicable for SUBORDINATE CertificateAuthorities
-	if d.Get("type") == "SUBORDINATE" {
+	// pem_csr is only applicable for SUBORDINATE CertificateAuthorities when their state is AWAITING_USER_ACTIVATION
+	if d.Get("type") == "SUBORDINATE" && d.Get("state") == "AWAITING_USER_ACTIVATION" {
 		url, err := replaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:fetch")
 		if err != nil {
 			return err

--- a/website/docs/d/privateca_certificate_authority.html.markdown
+++ b/website/docs/d/privateca_certificate_authority.html.markdown
@@ -6,7 +6,7 @@ description: |-
 ---
 # google_privateca_certificate_authority
 
-Get info about a Google Cloud IAP Client.
+Get info about a Google CAS Certificate Authority.
 
 ## Example Usage
 
@@ -42,4 +42,4 @@ The following arguments are supported:
 
 See [google_privateca_certificate_authority](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/privateca_certificate_authority) resource for details of the available attributes.
 
-* `pem_csr` - The PEM-encoded signed certificate signing request (CSR). This is only set on subordinate certificate authorities.
+* `pem_csr` - The PEM-encoded signed certificate signing request (CSR). This is only set on subordinate certificate authorities that are awaiting user activation.


### PR DESCRIPTION
Resolves #12432

Currently, attempting to use a `google_privateca_certificate_authority` for a `SUBORDINATE` CA in any state other than `AWAITING_USER_ACTIVATION` is impossible, because the Google API can only fetch the CSR in that state ([reference](https://cloud.google.com/certificate-authority-service/docs/reference/rest/v1/projects.locations.caPools.certificateAuthorities/fetch)). This prevents some really common use cases, like pulling an existing subordinate CA to issue leaf certs.

With this change, pulling a subordinate CA in any state other than `AWAITING_USER_ACTIVATION` will result in `pem_csr` simply being unset. If the subordinate CA is in `AWAITING_USER_ACTIVATION` and the CSR fetch fails, an error will still be thrown as expected.