### PR TITLE
Update release note generation command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Generate Release Notes
-        run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
+        run: |
+          export PREV_TAG=$(git tag -l --sort=-version:refname | head -n 2 | tail -n 1)
+          export PREV_VERSION=${PREV_TAG//v}
+          sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $PREV_VERSION/q;p" CHANGELOG.md > release-notes.txt
       - uses: actions/upload-artifact@v2
         with:
           name: release-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - name: Generate Release Notes
         run: |
-          export PREV_TAG=$(git tag -l --sort=-version:refname | head -n 2 | tail -n 1)
+          export PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n 2 | tail -n 1)
           export PREV_VERSION=${PREV_TAG//v}
           sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $PREV_VERSION/q;p" CHANGELOG.md > release-notes.txt
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Context

Closes https://github.com/hashicorp/terraform-provider-google/issues/12751

The release process owned by HashiCorp expects there to be an artifact, containing the release notes for a given release, uploaded to the repo containing the provider. [This is the section of the GHA workflow for this repo](https://github.com/hashicorp/terraform-provider-google/blob/3458a7ff3f69bd3a5402c844b40e5b80e0c54c83/.github/workflows/release.yml#L26-L32) that defines how the release notes are generated and then uploaded.

The `sed` command used to pull out the section of CHANGELOG.md relevant to the latest release is something made by HashiCorp : [see it here in the release tooling's README](https://github.com/hashicorp/ghaction-terraform-provider-release#setting-release-notes-from-changelog)

The `sed` command uses `git describe` to pull in the latest tag and then uses that output to identify the previous tag. This is used to prevent lines in the changelog from previous releases being streamed into the output `release-notes.txt` file. So if you tag v4.50.0 and the previous tag is v4.49.0 then you should see all of your changelog file above the entry for v4.49.0 being put into `release-notes.txt`.

# The problem

**Sometimes when we make a release we get lots of extra text in the release notes- changelog entries for multiple releases instead of just the latest release.**

This is because the `sed` command that generates the release notes needs to identify the tag for the current release we're making and _also_ the tag for the previous release. The previous release's tag/version is used to prevent those entries and older entries from being added to release notes.

For this to work, all the tags need to be reachable from the specified commit that the release is running from (i.e. where the latest tag was added), but because we tag release branches not all tags are accessible from main or branches coming off of main. This problem can be seen by checking out a tag and running the following command to see all the tags that are accessible from the tagged commit:

```bash
git checkout v4.42.0

git tag --merged | grep v4.
# v4.17.0
# v4.27.0
# v4.40.0
# v4.42.0
```

# Possible solution

The core issue we need to solve is how we can access the the previous release tag when we check out the most recent release tag.

This command returns all the tags in their release order (not just lexical order)

```
git tag --sort=-version:refname
```

You can pull the 2 most recent tags and then the bottom tag from that list of 2 to get the previous version:

```
git checkout v4.42.0

git tag --sort=-version:refname | head -n 2 | tail -n 1

# v4.41.0
```

# What's in this PR

I've used the above approach to update the `sed` command. Specifically I've replaced

```
$(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)
```

with

```
$PREV_VERSION
```

Where this ENV contains a value that is the previous version tag, minus the `v` at the start. E.g. `4.42.0`
