### PR TITLE
Update docs regarding `HTTP/2` in Cloud Run services

### DIFF
--- a/google/resource_cloud_run_service.go
+++ b/google/resource_cloud_run_service.go
@@ -307,7 +307,7 @@ https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort`,
 																Type:        schema.TypeString,
 																Computed:    true,
 																Optional:    true,
-																Description: `If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c".`,
+																Description: `If specified, used to specify which protocol to use. Allowed values are "http1" (HTTP/1) and "h2c" (HTTP/2 end-to-end)`,
 															},
 															"protocol": {
 																Type:        schema.TypeString,

--- a/website/docs/r/cloud_run_service.html.markdown
+++ b/website/docs/r/cloud_run_service.html.markdown
@@ -547,7 +547,7 @@ The following arguments are supported:
 
 * `name` -
   (Optional)
-  If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c".
+  If specified, used to specify which protocol to use. Allowed values are "http1" (HTTP/1) and "h2c" (HTTP/2 end-to-end)
 
 * `protocol` -
   (Optional)


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/12832