### PR TITLE
typo: Set cloudfunctions2_function.event_trigger.event_type to Required

### DIFF
--- a/website/docs/r/cloudfunctions2_function.html.markdown
+++ b/website/docs/r/cloudfunctions2_function.html.markdown
@@ -790,8 +790,8 @@ The following arguments are supported:
   region. If not provided, defaults to the same region as the function.
 
 * `event_type` -
-  (Optional)
-  Required. The type of event to observe.
+  (Required)
+  The type of event to observe.
 
 * `event_filters` -
   (Optional)


### PR DESCRIPTION
According to [API documentation](https://cloud.google.com/functions/docs/reference/rest/v2beta/projects.locations.functions), `cloudfunctions2_function.event_trigger.event_type` should be required.