### PR TITLE
Fix user-agent bug due to goreleaser ldflags not overriding value in release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X version.ProviderVersion={{.Version}}
+      - -s -w -X github.com/hashicorp/terraform-provider-google/version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   extra_files:


### PR DESCRIPTION
# Description

Partially closes https://github.com/hashicorp/terraform-provider-google/issues/13196

This PR fixes a bug where ldflags didn't work to override the default version value (`dev`). Currently this bug means that the user agent used by the provider doesn't reflect the provider version.


A full path is needed because the value defined isn't in the `main` package. You can see this already in action in the Makefile:

https://github.com/hashicorp/terraform-provider-google/blob/766f86a189d8088e555f6f085d09108c6f2e18e1/GNUmakefile#L14-L15