### PR TITLE
Use "Cloud Run" instead of "Cloud Run (2nd gen)"

### DIFF
--- a/website/docs/r/cloud_run_v2_job.html.markdown
+++ b/website/docs/r/cloud_run_v2_job.html.markdown
@@ -12,7 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
-subcategory: "Cloud Run (2nd gen)"
+subcategory: "Cloud Run"
 page_title: "Google: google_cloud_run_v2_job"
 description: |-
   A Cloud Run Job resource that references a container image which is run to completion.

--- a/website/docs/r/cloud_run_v2_service.html.markdown
+++ b/website/docs/r/cloud_run_v2_service.html.markdown
@@ -12,7 +12,7 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
-subcategory: "Cloud Run (2nd gen)"
+subcategory: "Cloud Run"
 page_title: "Google: google_cloud_run_v2_service"
 description: |-
   Service acts as a top-level container that manages a set of configurations and revision templates which implement a network service.


### PR DESCRIPTION
Fix #13414