### PR TITLE
Remove binary_authorization from google_cloud_run_v2_service basic example

### DIFF
--- a/google/resource_cloud_run_v2_service_generated_test.go
+++ b/google/resource_cloud_run_v2_service_generated_test.go
@@ -55,10 +55,6 @@ resource "google_cloud_run_v2_service" "default" {
   location = "us-central1"
   ingress = "INGRESS_TRAFFIC_ALL"
   
-  binary_authorization {
-    use_default = true
-    breakglass_justification = "Some justification"
-  }
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"

--- a/website/docs/r/cloud_run_v2_service.html.markdown
+++ b/website/docs/r/cloud_run_v2_service.html.markdown
@@ -43,10 +43,6 @@ resource "google_cloud_run_v2_service" "default" {
   location = "us-central1"
   ingress = "INGRESS_TRAFFIC_ALL"
   
-  binary_authorization {
-    use_default = true
-    breakglass_justification = "Some justification"
-  }
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"


### PR DESCRIPTION



Fix #13416