### PR TITLE
.github/workflows: Use hashicorp/ghaction-terraform-provider-release setup-go-version-file input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,6 @@ permissions:
   contents: write
 
 jobs:
-  go-version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.go-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v2
-      - id: go-version
-        run: echo "::set-output name=version::$(cat ./.go-version)"
   release-notes:
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +27,7 @@ jobs:
           retention-days: 1
   terraform-provider-release:
     name: 'Terraform Provider Release'
-    needs: [go-version, release-notes]
+    needs: [release-notes]
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
     secrets:
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
@@ -49,6 +41,6 @@ jobs:
       signore-client-secret: '${{ secrets.SIGNORE_CLIENT_SECRET }}'
     with:
       release-notes: true
-      setup-go-version: '${{ needs.go-version.outputs.version }}'
+      setup-go-version-file: '.go-version'
       # Product Version (e.g. v1.2.3 or github.ref_name)
       product-version: '${{ github.ref_name }}'


### PR DESCRIPTION
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v2.2.0
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/blob/7e53d9adb57f05cb16c227ef0bfd030060fae82e/.github/workflows/hashicorp.yml#L26-L29

Eventually gets passed through to action/setup-go's relatively new `go-version-file` input.

Please let me know if this needs to be submitted to magic-modules instead -- I didn't immediately see any template files for the .github/workflows directory upstream.