### PR TITLE
Update compute_region_backend_service default value for connection_draining_timeout_sec

### DIFF
--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -379,7 +379,7 @@ Defaults to 3.`,
 				Optional: true,
 				Description: `Time for which instance will be drained (not accept new
 connections, but still work to finish started).`,
-				Default: 0,
+				Default: 300,
 			},
 
 			"consistent_hash": {


### PR DESCRIPTION
Parallel fix to https://github.com/hashicorp/terraform-provider-google/pull/364 but for `google_compute_region_backend_service`. Brings terraform behavior in line with GCP defaults.

Fixes #13478