### PR TITLE
fix: update IAM policies atomically

### DIFF
--- a/google/resource_iam_policy.go
+++ b/google/resource_iam_policy.go
@@ -153,6 +153,9 @@ func setIamPolicyData(d *schema.ResourceData, updater ResourceIamUpdater) error 
 		return fmt.Errorf("'policy_data' is not valid for %s: %s", updater.DescribeResource(), err)
 	}
 	policy.Version = iamPolicyVersion
+	if v, ok := d.GetOk("etag"); ok {
+		policy.Etag = v.(string)
+	}
 
 	err = updater.SetResourceIamPolicy(policy)
 	if err != nil {


### PR DESCRIPTION
Include `Policy.Etag` when updating an IAM policy (such as the project IAM policy) to prevent race conditions. The etag is already set during `ResourceIamPolicyDelete`, but I noticed that it was not set during `ResourceIamPolicyUpdate`.

According to the [API reference for Policy](https://cloud.google.com/resource-manager/reference/rest/Shared.Types/Policy) (emphasis added):

> `etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. **It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions**: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that `etag` in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy.

I’m not sure whether `ResourceIamPolicyCreate` should set Policy.Etag to something like "" though; please provide PR feedback if so.

