### PR TITLE
Added the version needed for deletion_protection_enabled

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -243,6 +243,8 @@ The `settings` block supports:
 * `connector_enforcement` - (Optional) Specifies if connections must use Cloud SQL connectors.
 
 * `deletion_protection_enabled` - (Optional) Enables protection of an instance from accidental deletion protection across all surfaces (API, gcloud, Cloud Console and Terraform). Defaults to `false`.
+  
+  ~> **NOTE:** New is version 4.48.0.
 
 * `disk_autoresize` - (Optional) Enables auto-resizing of the storage size. Defaults to `true`.
 


### PR DESCRIPTION
The deletion_protection_enabled support was recently added. It makes sense to make this explicitly visible in the documentation.

As proposed in the following comment:
 - https://github.com/hashicorp/terraform-provider-google/issues/13398#issuecomment-1398752774