### PR TITLE
docs: update google_api_gateway_api_config

### DIFF
--- a/website/docs/r/api_gateway_api_config.html.markdown
+++ b/website/docs/r/api_gateway_api_config.html.markdown
@@ -47,7 +47,7 @@ resource "google_api_gateway_api" "api_cfg" {
 resource "google_api_gateway_api_config" "api_cfg" {
   provider = google-beta
   api = google_api_gateway_api.api_cfg.api_id
-  api_config_id = "cfg"
+  api_config_id_prefix = "cfg-"
 
   openapi_documents {
     document {


### PR DESCRIPTION
This PR updates the documentation of [google_api_gateway_api_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/api_gateway_api_config) to reflect its most common use case.

In its current version it leads to issues on any change due to this object requiring a `create_before_destroy` lifecycle. When using this option the argument `api_config_id_prefix` should be used instead of a fixed `api_config_id`. This is also described within the documentation of the [lifecycle argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle).