### PR TITLE
google_container_node_pool's pod_range should be `computed` to prevent diff

### DIFF
--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -342,6 +342,7 @@ var schemaNodePool = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Optional:    true,
 					ForceNew:    true,
+					Computed:    true,
 					Description: `The ID of the secondary range for pod IPs. If create_pod_range is true, this ID is used for the new range. If create_pod_range is false, uses an existing secondary range with this ID.`,
 				},
 				"pod_ipv4_cidr_block": {


### PR DESCRIPTION
As an example, if I create a pool with the following network config, it will not be in-state on a subsequent plan, due to the pod_range being generated by GCP:
```
  network_config {
    create_pod_range     = true
    enable_private_nodes = true
    pod_ipv4_cidr_block  = "192.168.80.0/20"
  }
```