### PR TITLE
issue template: Replace nightly build with test history 

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_test_failure.md
+++ b/.github/ISSUE_TEMPLATE/10_test_failure.md
@@ -23,9 +23,9 @@ title: "Failing test(s): TestAccWhatever"
 
 * google_XXXXX
 
-### Nightly builds
+### Teamcity test history
 
-<!-- Link to the nightly build(s), ideally with one impacted test opened -->
+<!-- Link to the test failure(s) page, ideally with one impacted test opened ie https://ci-oss.hashicorp.engineering/test/4373437493444570564?currentProjectId=GoogleCloudBeta&branch=%3Cdefault%3E -->
 - Link
 
 <!-- The error message that displays in the tests tab, for reference -->

--- a/.github/ISSUE_TEMPLATE/10_test_failure.md
+++ b/.github/ISSUE_TEMPLATE/10_test_failure.md
@@ -25,7 +25,7 @@ title: "Failing test(s): TestAccWhatever"
 
 ### Teamcity test history
 
-<!-- Link to the test failure(s) page, ideally with one impacted test opened ie https://ci-oss.hashicorp.engineering/test/4373437493444570564?currentProjectId=GoogleCloudBeta&branch=%3Cdefault%3E -->
+<!-- Link to the test failure(s) page ie https://ci-oss.hashicorp.engineering/test/4373437493444570564?currentProjectId=GoogleCloudBeta&branch=%3Cdefault%3E -->
 - Link
 
 <!-- The error message that displays in the tests tab, for reference -->

--- a/.github/ISSUE_TEMPLATE/10_test_failure.md
+++ b/.github/ISSUE_TEMPLATE/10_test_failure.md
@@ -23,7 +23,7 @@ title: "Failing test(s): TestAccWhatever"
 
 * google_XXXXX
 
-### Teamcity test history
+### Nightly build test history
 
 <!-- Link to the test failure(s) page ie https://ci-oss.hashicorp.engineering/test/4373437493444570564?currentProjectId=GoogleCloudBeta&branch=%3Cdefault%3E -->
 - Link


### PR DESCRIPTION
Nightly build links die after some time.. Test history link are much preferable so the data don't disappear. 