### PR TITLE
Update http_target uri of cloud scheduler

### DIFF
--- a/website/docs/r/cloud_scheduler_job.html.markdown
+++ b/website/docs/r/cloud_scheduler_job.html.markdown
@@ -77,7 +77,7 @@ resource "google_cloud_scheduler_job" "job" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://example.com/ping"
+    uri         = "https://example.com/"
     body        = base64encode("{\"foo\":\"bar\"}")
   }
 }


### PR DESCRIPTION
For cloud scheduler http job- POST method the existing URI was https://example.com/ping which is not an appropriate URI when I test this URI it gives 404 ERROR
![image](https://user-images.githubusercontent.com/60532803/222239388-45deabea-c6a4-41de-a3a1-713255f28620.png)
Hence I replace that URI with https://example.com/ and tested this resource locally, gives success.