### PR TITLE
Fix PubSub-to-BigQuery push configuration example

### DIFF
--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -162,7 +162,7 @@ resource "google_pubsub_subscription" "example" {
   topic = google_pubsub_topic.example.name
 
   bigquery_config {
-    table = "${google_bigquery_table.test.project}:${google_bigquery_table.test.dataset_id}.${google_bigquery_table.test.table_id}"
+    table = "${google_bigquery_table.test.project}.${google_bigquery_table.test.dataset_id}.${google_bigquery_table.test.table_id}"
   }
 
   depends_on = [google_project_iam_member.viewer, google_project_iam_member.editor]


### PR DESCRIPTION
API expects a dot instead of a colon for "fully-qualified" BigQuery table name