### PR TITLE
Adding .serviceDirectoryRegion to fwd rule

### DIFF
--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -262,6 +262,13 @@ func ComputeForwardingRuleServiceDirectoryRegistrationsSchema() *schema.Resource
 				ForceNew:    true,
 				Description: "Service Directory service to register the forwarding rule under.",
 			},
+			
+			"serviceDirectoryRegion": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Service Directory region to register this global forwarding rule under. Default to "us-central1". Only used for PSC for Google APIs. All PSC for Google APIs Forwarding Rules on the same network should use the same Service Directory region.",
+			},
 		},
 	}
 }


### PR DESCRIPTION
adding serviceDirectoryRegistrations[].serviceDirectoryRegion support to resource_compute_forwarding_rule.go
as per rest [api](https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules/insert#request-body)