### PR TITLE
google_compute_firewall: document that IPv6 ranges are permitted

### DIFF
--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -209,7 +209,7 @@ you create the resource.`,
 				Optional: true,
 				Description: `If destination ranges are specified, the firewall will apply only to
 traffic that has destination IP address in these ranges. These ranges
-must be expressed in CIDR format. Only IPv4 is supported.`,
+must be expressed in CIDR format. IPv4 or IPv6 are supported.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -276,7 +276,7 @@ sourceTags may be set. If both properties are set, the firewall will
 apply to traffic that has source IP address within sourceRanges OR the
 source IP that belongs to a tag listed in the sourceTags property. The
 connection does not need to match both properties for the firewall to
-apply. Only IPv4 is supported. For INGRESS traffic, one of 'source_ranges',
+apply. IPv4 or IPv6 are supported. For INGRESS traffic, one of 'source_ranges',
 'source_tags' or 'source_service_accounts' is required.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/google/resource_compute_firewall_test.go
+++ b/google/resource_compute_firewall_test.go
@@ -86,6 +86,24 @@ func TestAccComputeFirewall_localRanges(t *testing.T) {
 	})
 }
 
+func TestAccComputeFirewall_localRangesIPv6(t *testing.T) {
+	t.Parallel()
+
+	networkName := fmt.Sprintf("tf-test-firewall-%s", RandString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", RandString(t, 10))
+
+	VcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    TestAccProviders,
+		CheckDestroy: testAccCheckComputeFirewallDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeFirewall_localRangesIPv6(networkName, firewallName),
+			},
+		},
+	})
+}
+
 func TestAccComputeFirewall_priority(t *testing.T) {
 	t.Parallel()
 
@@ -359,6 +377,29 @@ resource "google_compute_firewall" "foobar" {
 
   source_ranges      = ["192.168.1.0/24"]
   destination_ranges = ["10.0.0.0/8"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+`, network, firewall)
+}
+
+func testAccComputeFirewall_localRangesIPv6(network, firewall string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_firewall" "foobar" {
+  name        = "%s"
+  description = "Resource created for Terraform acceptance testing"
+  network     = google_compute_network.foobar.name
+  source_tags = ["foo"]
+
+  source_ranges      = ["fd00::/8"]
+  destination_ranges = ["2001:0db8:3576:0d72::/64"]
 
   allow {
     protocol = "icmp"


### PR DESCRIPTION
See:
* https://cloud.google.com/compute/docs/reference/rest/v1/firewalls#Firewall.FIELDS.source_range
* https://cloud.google.com/compute/docs/reference/rest/v1/firewalls#Firewall.FIELDS.destination_range

This doesn't appear to actually enforce IPv4. So update the documentation and add an associated test.

fixes #14004