### PR TITLE
fix: enable service usage api on project creation

### DIFF
--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -188,7 +188,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 	// After creating this project no APIs will be enabled. If the user_project_override config is true
 	// and no billing_project is given, subsequent requests to list APIs via the serviceusage API will fail.
 	// This is caused by the list services request using this newly created project.ProjectId as the X-Goog-User-Project
-	// creating an impossbile to resovle situation without manuallying enabling the serviceusage API.
+	// creating an impossible to resolve situation without manually enabling the serviceusage API.
 	//
 	// Default enable serviceusage api to allow other services to be listed and enabled after project creation
 	// when enabling user_project_override without billing_project


### PR DESCRIPTION
Closes #14174 

Enable Service Usage API (serviceusage.googleapis.com) by default when creating new projects

After creating a project no APIs will be enabled. If the user_project_override config is true
and no billing_project is given, subsequent requests to list APIs via the serviceusage API will fail.
This is caused by the list services request using a newly created project.ProjectId as the X-Goog-User-Project
creating an impossibie to resolve situation without manually enabling the serviceusage API.

By default the Google Cloud console enables a set of service that is too broad to enable all by default: https://cloud.google.com/service-usage/docs/enabled-service#default

For this use case it makes sense to always enable the Service Usage API as it is required to list and enable any other services after creating a project.


Error output:

```console
Error: Error when reading or editing Project Service : Request `List Project Services XXXXXXXXXX` returned error: Batch request 
  and retried single request "List Project Services XXXXXXXXXX" both failed. Final error: Failed to list enabled services for project
  XXXXXXXXXX: googleapi: Error 403: Service Usage API has not been used in project XXXXXXXXXX before or it is disabled. Enable it by
  visiting https://console.developers.google.com/apis/api/serviceusage.googleapis.com/overview?project=XXXXXXXXXX then retry. If you
  enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.

Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.Help",
    "links": [
      {
        "description": "Google developers console API activation",
        "url": "https://console.developers.google.com/apis/api/serviceusage.googleapis.com/overview?project=XXXXXXXXXX"
      }
    ]
  },
  {
    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
    "domain": "googleapis.com",
    "metadata": {
      "consumer": "projects/XXXXXXXXXX",
      "service": "serviceusage.googleapis.com"
    },
    "reason": "SERVICE_DISABLED"
  }
]
, accessNotConfigured
```