### PR TITLE
Illustrate how a Pubsub Subscription `ttl` would be specified as indefinite

### DIFF
--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -411,7 +411,7 @@ The following arguments are supported:
   (Required)
   Specifies the "time-to-live" duration for an associated resource. The
   resource expires if it is not active for a period of ttl.
-  If ttl is not set, the associated resource never expires.
+  If ttl is not set (i.e. `ttl = ""`), the associated resource never expires.
   A duration in seconds with up to nine fractional digits, terminated by 's'.
   Example - "3.5s".
 


### PR DESCRIPTION
Because of the way a human might skim this doc, some are likely to wind up with the wrong default value. Imagine that someone has gone straight to the `ttl` section and missed the reference to a 31 day default in the `expiration_policy` section. They would likely then create an empty `expiration_policy` block and get a validation error. After removing that block altogether the validation error would disappear, but they would be left with a 31 day expiration rather than the indefinite one they had desired.