### PR TITLE
Adding the NOT_STARTED option to the desired_state documentation for datastream

### DIFF
--- a/google/resource_datastream_stream.go
+++ b/google/resource_datastream_stream.go
@@ -1267,7 +1267,7 @@ will be encrypted using an internal Stream-specific encryption key provisioned t
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "NOT_STARTED",
-				Description: `Desired state of the Stream. Set this field to 'RUNNING' to start the stream, and 'PAUSED' to pause the stream.`,
+				Description: `Desired state of the Stream. Set this field to 'RUNNING' to start the stream, 'NOT_STARTED' to not start the stream and 'PAUSED' to pause the stream from a 'RUNNING' state.`,
 			},
 			"project": {
 				Type:     schema.TypeString,

--- a/website/docs/r/datastream_stream.html.markdown
+++ b/website/docs/r/datastream_stream.html.markdown
@@ -1315,7 +1315,7 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs.
     If it is not provided, the provider project is used.
 
-* `desired_state` - (Optional) Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
+* `desired_state` - (Optional) Desired state of the Stream. Set this field to `RUNNING` to start the stream, `NOT_STARTED` to not start the stream and `PAUSED` to pause the stream from a `RUNNING` state.
 
 
 <a name="nested_backfill_all"></a>The `backfill_all` block supports:


### PR DESCRIPTION
 currently if you deploy with the PAUSED option set you will get the following error:

│ Error: `desired_state` can only be set to `NOT_STARTED` or `RUNNING` when creating a new Stream

The PAUSED option is only used for pausing currently running streams where the NOT_STARTED is used to deploy a stream without starting it.