### PR TITLE
typo in container_cluster.html.markdown (stack_type)

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -693,7 +693,7 @@ pick a specific range to use.
 
 * `stack_type` - (Optional) The IP Stack Type of the cluster. 
 Default value is `IPV4`.
-Possible values are `IPV4` and `PV4_IPV6`.
+Possible values are `IPV4` and `IPV4_IPV6`.
 
 <a name="nested_master_auth"></a>The `master_auth` block supports:
 


### PR DESCRIPTION
noticed a little typo in the documentation
PR got merged and closed #14079
Originally found in issue #13842