### PR TITLE
Update ambiguous description on spanner database

### DIFF
--- a/google/resource_spanner_database.go
+++ b/google/resource_spanner_database.go
@@ -205,7 +205,7 @@ update the database's version_retention_period.`,
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				Description: `Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
+				Description: `Whether or not to prevent Terraform from destroying the instance. Unless this field is set to false
 in Terraform state, a 'terraform destroy' or 'terraform apply' that would delete the instance will fail.`,
 			},
 			"project": {


### PR DESCRIPTION
The original description may mislead that `deletion_protection` allows Terraform to destroy the instance. This PR is to fix it