### PR TITLE
Update labeler.yml to address node12 deprecation

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,8 +8,8 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - uses: github/issue-labeler@a326d12b9b64d4395a18e50f648214c609501643
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+    - uses: github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c #v3.1.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
-    - uses: github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c #v3.1.0
+    - uses: github/issue-labeler@de16e742018d174ccf61d287f6ed31eb48faa64f #v2.6.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/14625

Affected action: https://github.com/hashicorp/terraform-provider-google/actions/workflows/labeler.yml

Updating actions/checkout from v2 to v3.5.2

Updating github/issue-labeler from v2.3 to v2.6

Related: https://github.com/hashicorp/terraform-provider-google/pull/14387



