### PR TITLE
Update lock.yml to address node12 deprecation

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,16 +8,16 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@486f7380c15596f92b724e4260e4981c68d6bde6
+      - uses: dessant/lock-threads@c1b35aecc5cdb1a34539d14196df55838bb2f836 #v4.0.0
         with:
           github-token: ${{ github.token }}
-          issue-lock-comment: >
+          issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-lock-inactive-days: '30'
-          pr-lock-comment: >
+          issue-inactive-days: '30'
+          pr-comment: >
             I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-lock-inactive-days: '30'
+          pr-inactive-days: '30'


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/14624

Affected action : https://github.com/hashicorp/terraform-provider-google/actions/workflows/lock.yml

Updating dessant/lock-threads to v4.0.0 addresses the node12 deprecation - [see CHANGELOG here](https://github.com/dessant/lock-threads/blob/master/CHANGELOG.md#400-2022-12-04).

As we're updating from v2.x to v4.x we [need to change the inputs to address breaking changes between v2.x and v3.x](https://github.com/dessant/lock-threads/blob/master/CHANGELOG.md#300-2021-09-27)

Related: https://github.com/hashicorp/terraform-provider-google/pull/14387