### PR TITLE
Update stale.yml to address node12 deprecation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757
+      - uses: actions/stale@99b6c709598e2b0d0841cd037aaf1ba07a4410bd #v5.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 9999


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/14622

Affected action : https://github.com/hashicorp/terraform-provider-google/actions/workflows/stale.yml

Updates from [v3.0.19](https://github.com/actions/stale/releases/tag/v3.0.19) to [v5.2.0](https://github.com/actions/stale/releases/tag/v5.2.0).

I decided to update to v5.2.0 as 5 introduced use of node16 and there were a few bug fixes that followed (5.1.0, 5.1.1, 5.2.0). I wanted to limit the upgrade as much as possible as there's a big jump between v3.0.19 and the latest v8.0.0 release.

Addressing breaking changes:
- The [breaking changes introduced in v4.x ](https://github.com/actions/stale/releases/tag/v4.0.0) are not relevant to how we use actions/stale
- [No breaking changes are listed for v5.x](https://github.com/actions/stale/releases/tag/v5.0.0)

Related: https://github.com/hashicorp/terraform-provider-google/pull/14387