### PR TITLE
update labeler so that removing a label isn't the default

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - uses: github/issue-labeler@a326d12b9b64d4395a18e50f648214c609501643
+    - uses: github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml


### PR DESCRIPTION
I think this ["breaking-change" ](https://github.com/github/issue-labeler/releases/tag/v3.0)is the one we want. They added an option `sync-labels` here and changed the default to "0", meaning, we don't want to sync labels by default (add on match, remove on !match), instead we want to just add on a match of the regex.