### PR TITLE
Update dependencies in issue-comment-created.yml

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -8,8 +8,8 @@ jobs:
   remove_waiting_response:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      - uses: actions-ecosystem/action-remove-labels@556e306654eb4c343ecaff657772edaa3f1add86
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+      - uses: hashicorp/action-remove-labels@abbd2b081f82911075bb66c5af1faa468a073be0 #v2.0.0
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           labels: waiting-response


### PR DESCRIPTION
This PR bumps the dependencies in issue-comment-created.yml.

Notably it switches from using actions-ecosystem/action-remove-labels to using hashicorp/action-remove-labels - an internal fork where the necessary updates to use Node 16 are included.