### PR TITLE
docs: add info for datapath_provider to enable Dataplane v2

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -346,7 +346,7 @@ subnetwork in which the cluster's instances are launched.
     The desired state of IPv6 connectivity to Google Services. By default, no private IPv6 access to or from Google Services (all access will be via IPv4).
 
 * `datapath_provider` - (Optional)
-    The desired datapath provider for this cluster. By default, uses the IPTables-based kube-proxy implementation.
+    The desired datapath provider for this cluster. By default, uses the IPTables-based kube-proxy implementation. Set to `ADVANCED_DATAPATH` to enable Dataplane v2.
 
 * `default_snat_status` - (Optional)
   [GKE SNAT](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent#how_ipmasq_works) DefaultSnatStatus contains the desired state of whether default sNAT should be disabled on the cluster, [API doc](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#networkconfig). Structure is [documented below](#nested_default_snat_status)


### PR DESCRIPTION
Here's a small MR that adds the info what to configure `datapath_provider` with to enable Dataplane v2.

This solves. https://github.com/hashicorp/terraform-provider-google/issues/13815