### PR TITLE
Fix condition to call api to fetch id token

### DIFF
--- a/google/services/resourcemanager/data_source_google_service_account_id_token.go
+++ b/google/services/resourcemanager/data_source_google_service_account_id_token.go
@@ -79,12 +79,13 @@ func dataSourceGoogleServiceAccountIdTokenRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error calling getCredentials(): %v", err)
 	}
 
-	// If the source credential is not a service account key, use the API to generate the idToken
-	if creds.JSON == nil {
+	targetServiceAccount := d.Get("target_service_account").(string)
+	// If a target service account is provided, use the API to generate the idToken
+	if targetServiceAccount != "" {
 		// Use
 		// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken
 		service := config.NewIamCredentialsClient(userAgent)
-		name := fmt.Sprintf("projects/-/serviceAccounts/%s", d.Get("target_service_account").(string))
+		name := fmt.Sprintf("projects/-/serviceAccounts/%s", targetServiceAccount)
 		tokenRequest := &iamcredentials.GenerateIdTokenRequest{
 			Audience:     targetAudience,
 			IncludeEmail: d.Get("include_email").(bool),
@@ -95,7 +96,7 @@ func dataSourceGoogleServiceAccountIdTokenRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("error calling iamcredentials.GenerateIdToken: %v", err)
 		}
 
-		d.SetId(d.Get("target_service_account").(string))
+		d.SetId(targetServiceAccount)
 		if err := d.Set("id_token", at.Token); err != nil {
 			return fmt.Errorf("Error setting id_token: %s", err)
 		}


### PR DESCRIPTION
I use GCE metadata server to authenticate and want to get id token.

```
  data "google_service_account_id_token" "oidc" {
    target_audience = "https://foo.bar/"
  }
```

The former condition `if creds.JSON == nil` prevents me from passing the line `idtoken.NewTokenSource()` and returns incomprehensible error message below: 

```
Error: error calling iamcredentials.GenerateIdToken: googleapi: got HTTP response code 404 with body: 

  with data.google_service_account_id_token.oidc,
  on provider.tf line 6, in data "google_service_account_id_token" "oidc":
   6: data "google_service_account_id_token" "oidc" {
```

I think this can be fixed by that the API is called only if target_service_account is provided.

