### PR TITLE
Update Replacement Method on Example

### DIFF
--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -177,7 +177,7 @@ update_policy {
   max_surge_percent              = 20
   max_unavailable_fixed          = 2
   min_ready_sec                  = 50
-  replacement_method             = "RECREATE"
+  replacement_method             = "SUBSTITUTE"
 }
 ```
 


### PR DESCRIPTION
Using the Example on the Documentation you get the following error 

`│ Error: Error updating region managed group instances: googleapi: Error 400: Invalid value for field 'resource.updatePolicy.maxSurge': '{  "percent": 20}'. maxSurge must be equal to 0 when replacement method is set to RECREATE, invalid`

I have updated the replacement method so that it can be copied directly