### PR TITLE
Add keepers to apikeys_key resource

### DIFF
--- a/google/services/apikeys/resource_apikeys_key.go
+++ b/google/services/apikeys/resource_apikeys_key.go
@@ -132,6 +132,13 @@ func ApikeysKeyRestrictionsSchema() *schema.Resource {
 				Elem:        ApikeysKeyRestrictionsIosKeyRestrictionsSchema(),
 			},
 
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
+
 			"server_key_restrictions": {
 				Type:        schema.TypeList,
 				Optional:    true,


### PR DESCRIPTION
This adds a "keepers" field (copied from service_account_key) to support automatic rotation using the time_rotating resource.

Closes: #15116