### PR TITLE
docs: fix broken Markdown link to terraform-provider-google-beta/releases

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -49,7 +49,7 @@ If you have configuration questions, or general questions about using the provid
 
 Interested in the provider's latest features, or want to make sure you're up to date?
 Check out the [`google` provider Releases](https://github.com/hashicorp/terraform-provider-google/releases)
-and the [`google-beta` provider Releases](https://github.com/hashicorp/terraform-provider-google-beta/releases
+and the [`google-beta` provider Releases](https://github.com/hashicorp/terraform-provider-google-beta/releases)
 for release notes and additional information.
 
 Per [Terraform Provider Versioning](https://www.hashicorp.com/blog/hashicorp-terraform-provider-versioning),


### PR DESCRIPTION
As mentioned in the PR title & the commit, this documentation PR fixes a broken Markdown link to https://github.com/hashicorp/terraform-provider-google-beta/releases (missing closing parenthesis).