### PR TITLE
Update actions/github-script version in issue-comment-created.yml

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -11,7 +11,7 @@ jobs:
   remove_waiting_response:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           REMOVE_LABEL: "waiting-response"
         with:


### PR DESCRIPTION
Update actions/github-script version in issue-comment-created.yml

I'm making this update so that the workflow file references the version via commit SHA instead of via tags.

The CHANGELOG for that action doesn't describe any breaking changes between v6 and v6.4.1, but to be safe I tested this change in my fork and found that the action still behaved as expected: https://github.com/SarahFrench/terraform-provider-google/pull/2#issuecomment-1637775874