### PR TITLE
Add ability to create assets as Managed.

### DIFF
--- a/google/services/dataplex/resource_dataplex_asset.go
+++ b/google/services/dataplex/resource_dataplex_asset.go
@@ -286,6 +286,12 @@ func DataplexAssetResourceSpecSchema() *schema.Resource {
 				ForceNew:    true,
 				Description: "Immutable. Relative name of the cloud resource that contains the data that is being managed within a lake. For example: `projects/{project_number}/buckets/{bucket_id}` `projects/{project_number}/datasets/{dataset_id}`",
 			},
+			"read_access_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Optional. Determines how read permissions are handled for each asset and their associated tables. Only available to storage buckets assets. Possible values: DIRECT, MANAGED."
+			},
 		},
 	}
 }


### PR DESCRIPTION
Add ability to create Dataplex assets as Managed. Taken from existing API spec: https://cloud.google.com/dataplex/docs/reference/rest/v1/projects.locations.lakes.zones.assets#accessmode 