### PR TITLE
client_secret: should be sensitive.

### DIFF
--- a/google/services/identityplatform/resource_identity_platform_tenant_default_supported_idp_config.go
+++ b/google/services/identityplatform/resource_identity_platform_tenant_default_supported_idp_config.go
@@ -57,6 +57,7 @@ func ResourceIdentityPlatformTenantDefaultSupportedIdpConfig() *schema.Resource 
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `OAuth client secret`,
+				Sensitive:   true,
 			},
 			"idp_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## WHAT

Adds the field `Sensitive` to the client_secret.

## WHY

This field should be a secret and it should not print during a plan.