### PR TITLE
Pin GitHub actions to commit SHAs of trusted versions

### DIFF
--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         repository: GoogleCloudPlatform/magic-modules
         path: repo
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         go-version: '^1.19.1'
     - name: Run backfill


### PR DESCRIPTION
These GHA versions are used in other workflows in this repo so I don't anticipate any issues.
Note: In October the HashiCorp GitHub organisation will not run any GHAs that are using untrusted versions and/or aren't referencing via commit SHA instead of tags.