### PR TITLE
Add content-type header to google_cloud_scheduler_job json examples

### DIFF
--- a/website/docs/r/cloud_scheduler_job.html.markdown
+++ b/website/docs/r/cloud_scheduler_job.html.markdown
@@ -79,6 +79,9 @@ resource "google_cloud_scheduler_job" "job" {
     http_method = "POST"
     uri         = "https://example.com/"
     body        = base64encode("{\"foo\":\"bar\"}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
   }
 }
 ```
@@ -107,6 +110,9 @@ resource "google_cloud_scheduler_job" "job" {
     http_method = "POST"
     uri         = "https://example.com/ping"
     body        = base64encode("{\"foo\":\"bar\"}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
   }
 }
 ```


### PR DESCRIPTION
By default scheduler calls with data as `Content-Type: application/octet-stream`. As examples are with json data, specifying `Content-Type: application/json`.

In helped me resolved an issue when calling GCP Cloud Functions (gen2), so I think that it will be valuable addition to the docs.