### PR TITLE
Fix `attempt_deadline` formatting in Cloud Scheduler job docs

### DIFF
--- a/website/docs/r/cloud_scheduler_job.html.markdown
+++ b/website/docs/r/cloud_scheduler_job.html.markdown
@@ -239,14 +239,16 @@ The following arguments are supported:
 
 * `attempt_deadline` -
   (Optional)
-  The deadline for job attempts. If the request handler does not respond by this deadline then the request is
+  The deadline for job attempts.  
+  A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".  
+  If the request handler does not respond by this deadline then the request is
   cancelled and the attempt is marked as a DEADLINE_EXCEEDED failure. The failed attempt can be viewed in
   execution logs. Cloud Scheduler will retry the job according to the RetryConfig.
   The allowed duration for this deadline is:
   * For HTTP targets, between 15 seconds and 30 minutes.
   * For App Engine HTTP targets, between 15 seconds and 24 hours.
   * **Note**: For PubSub targets, this field is ignored - setting it will introduce an unresolvable diff.
-  A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s"
+  
 
 * `retry_config` -
   (Optional)

--- a/website/docs/r/cloud_scheduler_job.html.markdown
+++ b/website/docs/r/cloud_scheduler_job.html.markdown
@@ -248,7 +248,6 @@ The following arguments are supported:
   * For HTTP targets, between 15 seconds and 30 minutes.
   * For App Engine HTTP targets, between 15 seconds and 24 hours.
   * **Note**: For PubSub targets, this field is ignored - setting it will introduce an unresolvable diff.
-  
 
 * `retry_config` -
   (Optional)


### PR DESCRIPTION
Fixes the formatting issue in the docs here, where the line is included in the bullet list, even though it has nothing to do with PubSub targets:
<img width="500" alt="Screenshot 2023-09-12 at 15 13 21" src="https://github.com/hashicorp/terraform-provider-google/assets/9994373/6eea4a0c-0c66-427e-9084-89dfc9cb4e4c">
