### PR TITLE
Don't fail plan if project,region,zone defaults cannot be retrieved

### DIFF
--- a/google/tpgresource/utils.go
+++ b/google/tpgresource/utils.go
@@ -754,7 +754,7 @@ func DefaultProviderProject(_ context.Context, diff *schema.ResourceDiff, meta i
 	if project := diff.Get("project"); project != nil {
 		project, err := GetProjectFromDiff(diff, config)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", project, err)
+			project = ""
 		}
 		err = diff.SetNew("project", project)
 		if err != nil {
@@ -771,7 +771,7 @@ func DefaultProviderRegion(_ context.Context, diff *schema.ResourceDiff, meta in
 	if region := diff.Get("region"); region != nil {
 		region, err := GetRegionFromDiff(diff, config)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve region, pid: %s, err: %s", region, err)
+			region = ""
 		}
 		err = diff.SetNew("region", region)
 		if err != nil {
@@ -789,7 +789,7 @@ func DefaultProviderZone(_ context.Context, diff *schema.ResourceDiff, meta inte
 	if zone := diff.Get("zone"); zone != nil {
 		zone, err := GetZoneFromDiff(diff, config)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve zone, pid: %s, err: %s", zone, err)
+			zone = ""
 		}
 		err = diff.SetNew("zone", zone)
 		if err != nil {


### PR DESCRIPTION
The DefaultProviderProject, DefaultProviderRegion and DefaultProviderZone funcs set respectively the project, region and zone in a diff if one is provided, unless they fetch the defaults from config. However, at times, these values may not be available during a plan, as they are dynamically computed at apply time.
We should avoid throwing an error if this is the case, but rather set an empty value in the diff.

Resolves hashicorp/terraform-provider-google#16133