### PR TITLE
Tweak default date and dry run description for the issue labeler action

### DIFF
--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -9,8 +9,9 @@ on:
       since:
         description: "The date to backfill tickets since in YYYY-MM-DD format"
         required: true
+        default: '1973-01-01'
       dry_run:
-        description: "Whether to skip actually updating issues"
+        description: "Dry run (no changes will be made to issues)"
         type: boolean
 
 jobs:


### PR DESCRIPTION
This is mainly intended to make usage a bit easier (we almost always use `1973-01-01`, to run against all tickets)