### PR TITLE
Revert "Update backfill-issue-labels.yml"

### DIFF
--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -31,5 +31,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{github.token}}
       run: |
-        cd repo/tools/issue-labeler/labeler
+        cd repo/tools/issue-labeler
         go run . -backfill-date=${{inputs.since}} -backfill-dry-run=${{inputs.dry_run}} -logtostderr=true


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-google#16501

Doesn't look like this is the right way to resolve the issue. Revert it for now. We may need to correct it in the magic-modules.