### PR TITLE
Update google_project_iam_custom_role.html.markdown to say custom role

### DIFF
--- a/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `permissions` (Required) The names of the permissions this role grants when bound in an IAM policy. At least one permission must be specified.
 
-* `project` - (Optional) The project that the service account will be created in.
+* `project` - (Optional) The project that the custom role will be created in.
     Defaults to the provider project configuration.
 
 * `stage` - (Optional) The current launch stage of the role.


### PR DESCRIPTION
I believe that the wording for this section is wrong, and should say "custom role". We're not creating a service account.