### PR TITLE
Do not replace GKE's NodePool resource on machineType/diskType/diskSi…

### DIFF
--- a/google/services/container/node_config.go
+++ b/google/services/container/node_config.go
@@ -65,7 +65,7 @@ func schemaNodeConfig() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ForceNew:     true,
+					ForceNew:     false,
 					ValidateFunc: validation.IntAtLeast(10),
 					Description:  `Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB.`,
 				},
@@ -74,7 +74,7 @@ func schemaNodeConfig() *schema.Schema {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Computed:    true,
-					ForceNew:    true,
+					ForceNew:    false,
 					Description: `Type of the disk attached to each node. Such as pd-standard, pd-balanced or pd-ssd`,
 				},
 
@@ -252,7 +252,7 @@ func schemaNodeConfig() *schema.Schema {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Computed:    true,
-					ForceNew:    true,
+					ForceNew:    false,
 					Description: `The name of a Google Compute Engine machine type.`,
 				},
 


### PR DESCRIPTION
…zeGb change

This is not possible using the user interface in GCP yet, but according to API this can be done and does not requires a replace.

  https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters.nodePools/update

"Initiates an upgrade operation that migrates the nodes in the node
 pool to the specified [machine type/disk type/disk size]."