### PR TITLE
Update regex for expected error in `TestAccContainerCluster_errorNoClusterCreated`

### DIFF
--- a/google/services/container/resource_container_cluster_test.go
+++ b/google/services/container/resource_container_cluster_test.go
@@ -3170,7 +3170,7 @@ func TestAccContainerCluster_errorNoClusterCreated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccContainerCluster_withInvalidLocation("wonderland"),
-				ExpectError: regexp.MustCompile(`Location "wonderland" does not exist.`),
+				ExpectError: regexp.MustCompile(`(Location "wonderland" does not exist)|(Permission denied on 'locations\/wonderland' \(or it may not exist\))`),
 			},
 		},
 	})


### PR DESCRIPTION
# Description

This test can fail due to incorrect error messages:

![Screenshot 2023-12-06 at 20 27 55](https://github.com/hashicorp/terraform-provider-google/assets/15078782/639a014a-1bc1-46c4-b5bc-eb7af1b7673c)

This PR updates the regex used to check the error.