### PR TITLE
Add error handling for ALREADY_EXISTS in IAM CreateServiceAccount call

### DIFF
--- a/google/services/resourcemanager/resource_google_service_account.go
+++ b/google/services/resourcemanager/resource_google_service_account.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 )
 
@@ -84,6 +85,12 @@ func ResourceGoogleServiceAccount() *schema.Resource {
 				Computed:    true,
 				Description: `The Identity of the service account in the form 'serviceAccount:{email}'. This value is often used to refer to the service account in order to grant IAM permissions.`,
 			},
+			"ignore_create_already_exists": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    false,
+				Description: `If set to true, skip service account creation if a service account with the same email already exists.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -116,7 +123,11 @@ func resourceGoogleServiceAccountCreate(d *schema.ResourceData, meta interface{}
 
 	sa, err = config.NewIamClient(userAgent).Projects.ServiceAccounts.Create("projects/"+project, r).Do()
 	if err != nil {
-		return fmt.Errorf("Error creating service account: %s", err)
+		gerr, ok := err.(*googleapi.Error)
+		alreadyExists := ok && gerr.Code == 409 && d.Get("ignore_create_already_exists").(bool)
+		if !alreadyExists {
+			return fmt.Errorf("Error creating service account: %s", err)
+		}
 	}
 
 	d.SetId(sa.Name)

--- a/google/services/resourcemanager/resource_google_service_account_test.go
+++ b/google/services/resourcemanager/resource_google_service_account_test.go
@@ -56,6 +56,16 @@ func TestAccServiceAccount_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test creating a service account that already exists.
+			{
+				Config: testAccServiceAccountIgnoreCreateAlreadyExists(accountId, displayName, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "project", project),
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "member", "serviceAccount:"+expectedEmail),
+				),
+			},
 			// The second step updates the service account
 			{
 				Config: testAccServiceAccountBasic(accountId, displayName2, desc2),
@@ -164,6 +174,17 @@ resource "google_service_account" "acceptance" {
   account_id   = "%v"
   display_name = "%v"
   description  = "%v"
+}
+`, account, name, desc)
+}
+
+func testAccServiceAccountIgnoreCreateAlreadyExists(account, name, desc string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "acceptance" {
+  account_id   = "%v"
+  display_name = "%v"
+  description  = "%v"
+  ignore_create_already_exists = true
 }
 `, account, name, desc)
 }


### PR DESCRIPTION
This change introduces an optional resource argument to Google Cloud IAM Service Account. If `ignore_create_already_exists` is set to true, resource creation would succeed if response error is 409 ALREADY_EXISTS.

Fix #16185

Fix #10193