### PR TITLE
docs: Fix user_env_vars string limit

### DIFF
--- a/website/docs/r/workflows_workflow.html.markdown
+++ b/website/docs/r/workflows_workflow.html.markdown
@@ -129,7 +129,7 @@ The following arguments are supported:
 
 * `user_env_vars` -
   (Optional)
-  User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 40KiB. Keys cannot be empty strings and cannot start with “GOOGLE” or “WORKFLOWS".
+  User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 4KiB. Keys cannot be empty strings and cannot start with “GOOGLE” or “WORKFLOWS".
 
 * `region` -
   (Optional)


### PR DESCRIPTION
Per Google bug b/317352649