### PR TITLE
Fixed problem with issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/12_bug_test_form.yml
+++ b/.github/ISSUE_TEMPLATE/12_bug_test_form.yml
@@ -1,6 +1,6 @@
-name: [TEST] Bug
-labels: bug
-description: [TEST] For when something is there, but doesn't work how it should.
+name: "[TEST] Bug"
+labels: ["bug"]
+description: "[TEST] For when something is there, but doesn't work how it should."
 body:
   - type: textarea
     id: community-note


### PR DESCRIPTION
I think that the problem is that the `[` was interpreted as starting an array instead of being part of a string? But the error message was not super clear: https://github.com/hashicorp/terraform-provider-google/blob/main/.github/ISSUE_TEMPLATE/12_bug_test_form.yaml

The error does not show up on this branch's version of the file. I also moved it to `.yml` to match the example on https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms just in case that somehow is also an issue.