### PR TITLE
Update GNUmakefile to include `teamcity-test` target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,4 +48,8 @@ endif
 docscheck:
 	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
 
+teamcity-test:
+	@$(MAKE) -C .teamcity tools
+	@$(MAKE) -C .teamcity test
+
 .PHONY: build test testnolint testacc fmt fmtcheck vet lint test-compile website website-test docscheck


### PR DESCRIPTION
Relates to but doesn't close : https://github.com/hashicorp/terraform-provider-google/issues/17231

I'm trying to keep the GHA for running TeamCity tests as close to what the Azure team uses as possible, so that they can help with debugging any issues I encounter.

Here's this Makefile target in the Azure provider: https://github.com/hashicorp/terraform-provider-azurerm/blob/0ea6b55b924500c3e950dd3c2a7520c81d934055/GNUmakefile#L136-L138

They use this Makefile target in their GHAs, so I'm introducing it to the TPG repo in this PR. The TPGB won't contain TeamCity configuration so I'm intentionally only adding this target here.