### PR TITLE
docs: fix import example in google_project_iam

### DIFF
--- a/website/docs/r/google_project_iam.html.markdown
+++ b/website/docs/r/google_project_iam.html.markdown
@@ -228,7 +228,7 @@ An [`import` block](https://developer.hashicorp.com/terraform/language/import) (
 
 ```tf
 import {
-  id = ""{{project_id}} roles/viewer user:foo@example.com"m"
+  id = "{{project_id}} roles/viewer user:foo@example.com"
   to = google_project_iam_member.default
 }
 ```


### PR DESCRIPTION
## What

Fix the example in the `google_project_iam` documentation.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#import