### PR TITLE
Fix broken datasource google_compute_machine_types example

### DIFF
--- a/website/docs/d/compute_machine_types.html.markdown
+++ b/website/docs/d/compute_machine_types.html.markdown
@@ -20,7 +20,7 @@ Configure a Google Kubernetes Engine (GKE) cluster with node auto-provisioning, 
 
 ```hcl
 data "google_compute_machine_types" "example" {
-  filter = "name = 'n1-standard-1'"
+  filter = "name = \"n1-standard-1\""
   zone   = "us-central1-a"
 }
 


### PR DESCRIPTION
The query doesn't work with single quotes. This needs to be double.