### PR TITLE
Docs: fix typo in google_project_iam doc

### DIFF
--- a/website/docs/r/google_project_iam.html.markdown
+++ b/website/docs/r/google_project_iam.html.markdown
@@ -228,7 +228,7 @@ An [`import` block](https://developer.hashicorp.com/terraform/language/import) (
 
 ```tf
 import {
-  id = ""{{project_id}} roles/viewer user:foo@example.com"m"
+  id = ""{{project_id}} roles/viewer user:foo@example.com"
   to = google_project_iam_member.default
 }
 ```


### PR DESCRIPTION
Very minor fix of a typo in the import block