### PR TITLE
Added test failure issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/13_test_failure.yml
+++ b/.github/ISSUE_TEMPLATE/13_test_failure.yml
@@ -14,6 +14,8 @@ body:
       description: List all impacted tests for searchability. The title of the issue can instead list one or more groups of tests, or describe the overall root cause.
       value: |
         - TestAccWhatever
+    validations:
+      required: true
   - type: textarea
     id: affected-resources
     attributes:
@@ -21,6 +23,8 @@ body:
       description: List the primary resource or data source under test, even if the root cause of the failure is in a different resource. Use `google_*` for tests related to core provider logic.
       value: |
         - google_XXXXX
+    validations:
+      required: true
   - type: textarea
     id: failure-rates
     attributes:
@@ -29,6 +33,8 @@ body:
       value: |
         - 100% since YYYY-MM-DD
         - X% as of YYYY-MM-DD (Y/120 runs)
+    validations:
+      required: true
   - type: textarea
     id: messages
     attributes:
@@ -38,6 +44,8 @@ body:
         ```
         
         ```
+    validations:
+      required: true
   - type: textarea
     id: test-history
     attributes:
@@ -45,3 +53,5 @@ body:
       description: Link to the [test history page](https://hashicorp.teamcity.com/test/1458901879521596451?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS&expandTestHistoryChartSection=true) for the failed test.
       value: |
         - https://hashicorp.teamcity.com/...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/13_test_failure.yml
+++ b/.github/ISSUE_TEMPLATE/13_test_failure.yml
@@ -32,7 +32,7 @@ body:
       description: For 100% test failures, provide the start date. For flakey tests, use as much of the test history as seems relevant.
       value: |
         - 100% since YYYY-MM-DD
-        - X% as of YYYY-MM-DD (Y/120 runs)
+        - X% (Y failed out of last Z runs) as of YYYY-MM-DD
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/13_test_failure.yml
+++ b/.github/ISSUE_TEMPLATE/13_test_failure.yml
@@ -1,0 +1,47 @@
+name: "[TEST] Test failure"
+labels: ["test-failure"]
+description: "[TEST] (Internal) For reporting test failures on the nightly builds"
+title: "Failing test(s): TestAccWhatever"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a template for reporting test failures on nightly builds. It should only be used by core contributors who have access to our CI/CD results.
+  - type: textarea
+    id: impacted-tests
+    attributes:
+      label: Impacted tests
+      description: List all impacted tests for searchability. The title of the issue can instead list one or more groups of tests, or describe the overall root cause.
+      value: |
+        - TestAccWhatever
+  - type: textarea
+    id: affected-resources
+    attributes:
+      label: Affected Resource(s)
+      description: List the primary resource or data source under test, even if the root cause of the failure is in a different resource. Use `google_*` for tests related to core provider logic.
+      value: |
+        - google_XXXXX
+  - type: textarea
+    id: failure-rates
+    attributes:
+      label: Failure rates
+      description: For 100% test failures, provide the start date. For flakey tests, use as much of the test history as seems relevant.
+      value: |
+        - 100% since YYYY-MM-DD
+        - X% as of YYYY-MM-DD (Y/120 runs)
+  - type: textarea
+    id: messages
+    attributes:
+      label: Message(s)
+      description: The error message that displays in the tests tab, for reference. Project IDs are okay to share, but do check for other sensitive information.
+      value: |
+        ```
+        
+        ```
+  - type: textarea
+    id: test-history
+    attributes:
+      label: Nightly build test history
+      description: Link to the [test history page](https://hashicorp.teamcity.com/test/1458901879521596451?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS&expandTestHistoryChartSection=true) for the failed test.
+      value: |
+        - https://hashicorp.teamcity.com/...


### PR DESCRIPTION
Test version of the form - if this looks good after merge I'll move it to replace the existing test failure template.

I've fixed the issue where test failures don't get a label, and also reordered the fields to put failure rates and links to the test history lower (since they are less important, generally speaking.)