### PR TITLE
chore: update Cloud SQL `instances` field description

### DIFF
--- a/website/docs/r/cloud_run_v2_service.html.markdown
+++ b/website/docs/r/cloud_run_v2_service.html.markdown
@@ -970,7 +970,7 @@ The following arguments are supported:
 
 * `instances` -
   (Optional)
-  The Cloud SQL instance connection names, as can be found in https://console.cloud.google.com/sql/instances. Visit https://cloud.google.com/sql/docs/mysql/connect-run for more information on how to connect Cloud SQL and Cloud Run. Format: {project}:{location}:{instance}
+  The list of Cloud SQL instance connection names, as can be found in https://console.cloud.google.com/sql/instances. Visit https://cloud.google.com/sql/docs/mysql/connect-run for more information on how to connect Cloud SQL and Cloud Run. Format: [{project}:{location}:{instance}]
 
 <a name="nested_empty_dir"></a>The `empty_dir` block supports:
 


### PR DESCRIPTION
The documentation is imprecise regarding the correct type for the `instances` field. Especially considering that this value used to be a comma separated string for the cloud run v1 API.