### PR TITLE
Update docscheck.sh to accept provider function docs

### DIFF
--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -27,6 +27,15 @@ for doc in $docs; do
       fi
       ;;
 
+    "functions")
+      # Functions require a page_title
+      grep "^page_title: " "$doc" > /dev/null
+      if [[ "$?" == "1" ]]; then
+        echo "Doc is missing a page_title: $doc"
+        error=true
+      fi
+      ;;
+
     *)
       error=true
       echo "Unknown category \"$category\". " \


### PR DESCRIPTION
(This docscheck.sh script is a good candidate for being replaced with official tools, but for now updating this script to avoid false alarms about bad docs)

After merging this PR I'll cherry pick the commit from main into the feature branch.


---

Manual test without this edit to docscheck.sh:
- If I add the file `website/docs/functions/example.html.markdown` with [example docs content from here](https://developer.hashicorp.com/terraform/plugin/framework/functions/documentation#registry-based-documentation) to the TPG repo 
- and then run `make docscheck`
- I see:

```
terraform-provider-google % make docscheck
Unknown category "functions".  Docs can only exist in r/, d/, or guides/ folders.
make: *** [docscheck] Error 1
```

Manual test without this edit to docscheck.sh:
- Given a repo with the new file described above
- If I update the script as per this PR and then run `make docscheck` I see no output:

```
terraform-provider-google % make docscheck
```
