### PR TITLE
Update compute_backend_bucket_signed_url_key.html.markdown

### DIFF
--- a/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
+++ b/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
@@ -42,7 +42,7 @@ resource "random_id" "url_signature" {
 
 resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
   name           = "test-key"
-  key_value      = random_id.url_signature.b64_url
+  key_value      = random_id.url_signature.b64_std
   backend_bucket = google_compute_backend_bucket.test_backend.name
 }
 


### PR DESCRIPTION
The key needs to be stored in b64_std format or else it doesn't work.