### PR TITLE
Fix unit tests to fail if a package does not compile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-TEST?=$$(go list ./... | grep -v github.com/hashicorp/terraform-provider-google/scripts)
+TEST?=$$(go list -e ./... | grep -v github.com/hashicorp/terraform-provider-google/scripts)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=google
 DIR_NAME=google


### PR DESCRIPTION
This fixes certain failures (like https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8605470129/job/23581794578#step:8:1) that incorrectly report success.

Basically, the `go list` command will exit with 1 by default if there are compiler errors, but still return all of the packages that did compile. Since it's return value is used as an argument to `go test`, the exit code is ignored, and the failed package is never checked by `go test`.

By using the `-e` argument, `go list` will include the failed package in its results, and the `go test` will fail as expected on that package and exit with 1.