### PR TITLE
Update bug issue template to include "provider version" in section title

### DIFF
--- a/.github/ISSUE_TEMPLATE/00_bug.yml
+++ b/.github/ISSUE_TEMPLATE/00_bug.yml
@@ -18,7 +18,7 @@ body:
   - type: textarea
     id: terraform-version
     attributes:
-      label: Terraform Version & Provider Version
+      label: Terraform Version & Provider Version(s)
       description: |
         Please run [`terraform version`](https://developer.hashicorp.com/terraform/cli/commands/version) to show the Terraform core version and provider version(s) and paste the output here.
         If you are not running the latest version of Terraform or the provider, please upgrade because your issue may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/00_bug.yml
+++ b/.github/ISSUE_TEMPLATE/00_bug.yml
@@ -22,6 +22,11 @@ body:
       description: |
         Please run [`terraform version`](https://developer.hashicorp.com/terraform/cli/commands/version) to show the Terraform core version and provider version(s) and paste the output here.
         If you are not running the latest version of Terraform or the provider, please upgrade because your issue may have already been fixed.
+      value: |
+        Terraform vX.X.X
+        on <architecture>
+        + provider registry.terraform.io/hashicorp/google vX.X.X
+        + provider registry.terraform.io/hashicorp/google-beta vX.X.X
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/00_bug.yml
+++ b/.github/ISSUE_TEMPLATE/00_bug.yml
@@ -18,7 +18,7 @@ body:
   - type: textarea
     id: terraform-version
     attributes:
-      label: Terraform Version
+      label: Terraform Version & Provider Version
       description: |
         Please run [`terraform version`](https://developer.hashicorp.com/terraform/cli/commands/version) to show the Terraform core version and provider version(s) and paste the output here.
         If you are not running the latest version of Terraform or the provider, please upgrade because your issue may have already been fixed.


### PR DESCRIPTION
In some bug issues users report their Terraform version but not the provider version - by updating the title of the section we might be able to correct this a little?