### PR TITLE
Update GHA for releases to use Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v3
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v4
     secrets:
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
       hc-releases-host-staging: '${{ secrets.HC_RELEASES_HOST_STAGING }}'


### PR DESCRIPTION
See: https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v4.0.0

This version of the GHA avoids issues with Node 16 deprecation