### PR TITLE
Update reviewer lottery GitHub action, update reviewer list

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,13 +1,20 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
+# See https://github.com/kentaro-m/auto-assign-action?tab=readme-ov-file#single-reviewers-list
 
-groups:
-  - name: devs
-    reviewers: 1
-    usernames:
-      - rileykarson
-      - slevenick
-      - c2thorn
-      - scottsuarez
-      - melinath
-      - shuyama1
+addReviewers: true # add reviewers to pull requests
+
+addAssignees: false # don't add assignees to pull requests
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - rileykarson
+  - slevenick
+  - c2thorn
+  - scottsuarez
+  - melinath
+  - shuyama1
+  - SarahFrench
+  - BBBmau
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1

--- a/.github/workflows/pull-request-reviewer.yml
+++ b/.github/workflows/pull-request-reviewer.yml
@@ -7,11 +7,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  test:
+  add-reviewer:
     if: ${{ github.actor != 'modular-magician' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - uses: uesteibar/reviewer-lottery@c291d74388da1cb583aff994b8be945e8eefbcd5 # v3.1.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e # v2.0.0
+        with:
+          configuration-path: ".github/reviewer-lottery.yml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+


### PR DESCRIPTION
`uesteibar/reviewer-lottery` doesn't support Node 20 and seems under-maintained, whereas `kentaro-m/auto-assign-action` uses Node 20: https://github.com/kentaro-m/auto-assign-action/commit/6dcb6521ab1eea0cef72c16b3719a3f4c110a485

Making this change will help us to address Node 16's deprecation in GitHub