### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/google/services/compute/metadata.go
+++ b/google/services/compute/metadata.go
@@ -86,7 +86,7 @@ func BetaMetadataUpdate(oldMDMap map[string]interface{}, newMDMap map[string]int
 }
 
 func expandComputeMetadata(m map[string]interface{}) []*compute.MetadataItems {
-	metadata := make([]*compute.MetadataItems, len(m))
+	metadata := make([]*compute.MetadataItems, 0, len(m))
 	var keys []string
 	for key := range m {
 		keys = append(keys, key)

--- a/google/services/compute/resource_compute_subnetwork.go
+++ b/google/services/compute/resource_compute_subnetwork.go
@@ -345,8 +345,8 @@ func resourceComputeSubnetworkSecondaryIpRangeSetStyleDiff(_ context.Context, di
 	if count < 1 {
 		return nil
 	}
-	old := make([]interface{}, count)
-	new := make([]interface{}, count)
+	old := make([]interface{}, 0, count)
+	new := make([]interface{}, 0, count)
 	for i := 0; i < count; i++ {
 		o, n := diff.GetChange(fmt.Sprintf("secondary_ip_range.%d", i))
 


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242968654/job/25426481866

```
====================================================================================================
append to slice `metadata` with non-zero initialized length at https://github.com/hashicorp/terraform-provider-google/blob/main/google/services/compute/metadata.go#L[9](https://github.com/alingse/go-linter-runner/actions/runs/9242968654/job/25426481866#step:4:10)8:14
append to slice `old` with non-zero initialized length at https://github.com/hashicorp/terraform-provider-google/blob/main/google/services/compute/resource_compute_subnetwork.go#L354:[10](https://github.com/alingse/go-linter-runner/actions/runs/9242968654/job/25426481866#step:4:11)
append to slice `new` with non-zero initialized length at https://github.com/hashicorp/terraform-provider-google/blob/main/google/services/compute/resource_compute_subnetwork.go#L357:10
====================================================================================================
```