### PR TITLE
`TeamCity`: update cronjob to run `teamcity-nightly-tests.yaml` only on weekdays

### DIFF
--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -10,7 +10,7 @@ on:
         dayThreshold:
           default: '3'
     schedule:
-        - cron: '0 4 * * *'
+        - cron: '0 4 * * 1-5' # we only want to run nightly tests on weekdays
 
 jobs:
   nigthly-test-branch-creation:


### PR DESCRIPTION
Discussed in this PR:

https://github.com/GoogleCloudPlatform/magic-modules/pull/10785#issuecomment-2159961230