### PR TITLE
TeamCity: update nightly workflow to use static branch

### DIFF
--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -11,7 +11,7 @@ on:
         dayThreshold:
           default: '3'
     schedule:
-        - cron: '0 14 * * *' # UTC 2PM (-7)-> 7AM PST
+        - cron: '0 9 * * *' # UTC 9AM (-7)-> 2PM PST
 
 jobs:
   rename-TC-nightly-branch:

--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -1,7 +1,8 @@
 name: "TeamCity: Remove branches used for nightly test"
 
 
-# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+# To ensure TeamCity build is triggered by the newly created branch. We prevent their to be only
+# one branch that matches the filter (+:UTC-*,-:UTC-nightly-tests*)
 
 on:
     workflow_call:
@@ -23,7 +24,7 @@ jobs:
           script: |
                   let dateToday = new Date().toJSON().slice(0, 10);
                   const oldBranchName = "UTC-" + dateToday;
-                  const newBranchName = "UTC-nightly-tests" + dateToday;
+                  const newBranchName = "UTC-nightly-tests-" + dateToday;
                   
                   try{
                   await github.rest.repos.renameBranch({
@@ -33,7 +34,7 @@ jobs:
                     new_name: newBranchName, 
                   })
                   } catch (error){
-                    core.setFailed(error + "- Failed to rename branch to be used running tonight\'s tests; branch with name " + oldBranchName + " doesn\'t exist")
+                    core.setFailed(error + "- Failed to rename branch; branch with name " + oldBranchName + " doesn\'t exist")
                   }
                   console.log("Renamed branch " + oldBranchName + " to " + newBranchName)
 

--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -1,8 +1,8 @@
 name: "TeamCity: Remove branches used for nightly test"
 
 
-# To ensure TeamCity build is triggered by the newly created branch. We prevent their to be only
-# one branch that matches the filter (+:UTC-*,-:UTC-nightly-tests*)
+# TeamCity should use a newly created branches that matches the pattern `UTC-<YYYY-MM-DD>` and is the only branch matching that pattern. We rename past nightly test branches to avoid there being more than one `UTC-<YYYY-MM-DD>` branch (i.e. only one branch that matches the filter (+:UTC-*,-:UTC-nightly-tests*)). This workflow also removes renamed branches once they get past a certain age. 
+# ```
 
 on:
     workflow_call:

--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -69,7 +69,7 @@ jobs:
                   })
 
                 const filteredBranches = branchList.data.filter( (branch) => {
-                  const branchDate = /^UTC-nightly-\d{4}-\d{2}-\d{2}$/g.exec(branch.name)
+                  const branchDate = /^UTC-nightly-tests-\d{4}-\d{2}-\d{2}$/g.exec(branch.name)
                   return branchDate != null  // skips if regex fails (is successful if matches with UTC-nightly-test branch format)
                 })
 

--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -1,0 +1,101 @@
+name: "TeamCity: Remove branches used for nightly test"
+
+
+# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+
+on:
+    workflow_call:
+    workflow_dispatch:
+      inputs:
+        dayThreshold:
+          default: '3'
+    schedule:
+        - cron: '0 14 * * *' # UTC 2PM (-7)-> 7AM PST
+
+jobs:
+  rename-TC-nightly-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400, 401, 403, 404, 422
+          script: |
+                  let dateToday = new Date().toJSON().slice(0, 10);
+                  const oldBranchName = "UTC-" + dateToday;
+                  const newBranchName = "UTC-nightly-tests" + dateToday;
+                  
+                  try{
+                  await github.rest.repos.renameBranch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    branch: oldBranchName,
+                    new_name: newBranchName, 
+                  })
+                  } catch (error){
+                    core.setFailed(error + "- Failed to rename branch to be used running tonight\'s tests; branch with name " + oldBranchName + " doesn\'t exist")
+                  }
+                  console.log("Renamed branch " + oldBranchName + " to " + newBranchName)
+
+  sweeping-outdated-branches:
+    needs: rename-TC-nightly-branch
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
+        env:
+          DAYS_THRESHOLD: ${{ inputs.dayThreshold || '3'}} # this allows the default value to be 3 when triggered on schedule
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400, 401, 403, 404, 422
+          script: |
+            const { DAYS_THRESHOLD } = process.env
+            console.log(`Removing nightly-test branches not made in the last ${DAYS_THRESHOLD} days`)
+        
+            function dateDifference(dateToday, branchDate){
+                dateToday = new Date(dateToday)
+                branchDate = new Date(branchDate)
+                return (dateToday - branchDate) / 86_400_000 // calculates the difference in days based on milliseconds
+            }
+            
+            async function branchSweeper(daysThreshold){
+                let dateToday = new Date().toJSON().slice(0, 10);
+                console.log("Today\'s date: ",dateToday);
+                // grab the list of branches then iterate through the list checking for the difference in days
+                const branchList = await github.rest.repos.listBranches({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    protected: false
+                  })
+
+                const filteredBranches = branchList.data.filter( (branch) => {
+                  const branchDate = /^UTC-nightly-\d{4}-\d{2}-\d{2}$/g.exec(branch.name)
+                  return branchDate != null  // skips if regex fails (is successful if matches with UTC-nightly-test branch format)
+                })
+
+                let branchesToDelete = []
+                
+                for (let i = 0; i < filteredBranches.length; i++) {
+                    const branchName = filteredBranches.at(i).name
+                    const branchDate = /\d{4}-\d{1,2}-\d{1,2}/g.exec(branchName)
+                    if (dateDifference(dateToday, branchDate[0]) >= daysThreshold) { // only happens if difference is greater than or equal to 3, we only want to keep the last 3 night branches
+                      branchesToDelete.push(branchName)
+                    }
+                }
+                
+                console.log("branches to be deleted: " + branchesToDelete)
+
+                for (let i = 0; i < branchesToDelete.length; i++) {
+                  const resp = await github.rest.git.deleteRef({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: "heads/" + branchesToDelete[i],
+                    })
+                  if (resp.status == "422"){
+                      console.error("Branch doesn\'t exist")
+                  } else{
+                    console.log("Deleted branch: " + branchesToDelete[i])
+                  } 
+                }
+            }
+          
+            branchSweeper(DAYS_THRESHOLD)

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -10,7 +10,7 @@ on:
         dayThreshold:
           default: '3'
     schedule:
-        - cron: '0 4 * * *'
+        - cron: '0 4 * * *' # UTC 4AM (-7)-> 9PM PST
 
 jobs:
   nigthly-test-branch-creation:
@@ -28,7 +28,7 @@ jobs:
                     repo: context.repo.repo,
                     ref: "heads/main"
                   })
-                  const branchName = "UTC-nightly-tests-" + dateToday;
+                  const branchName = "UTC-" + dateToday;
                   try{
                   await github.rest.git.createRef({
                     owner: context.repo.owner,
@@ -40,66 +40,3 @@ jobs:
                     core.setFailed(error + "- Failed to create new branch to be used running tonight\'s tests; branch with name " + branchName + " already exists")
                   }
                   console.log("Created Branch: " + branchName)
-
-  sweeping-outdated-branches:
-    needs: nigthly-test-branch-creation
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
-        env:
-          DAYS_THRESHOLD: ${{ inputs.dayThreshold || '3'}} # this allows the default value to be 3 when triggered on schedule
-        with:
-          retries: 3
-          retry-exempt-status-codes: 400, 401, 403, 404, 422
-          script: |
-            const { DAYS_THRESHOLD } = process.env
-            console.log(`Removing nightly-test branches not made in the last ${DAYS_THRESHOLD} days`)
-        
-            function dateDifference(dateToday, branchDate){
-                dateToday = new Date(dateToday)
-                branchDate = new Date(branchDate)
-                return (dateToday - branchDate) / 86_400_000 // calculates the difference in days based on milliseconds
-            }
-            
-            async function branchSweeper(daysThreshold){
-                let dateToday = new Date().toJSON().slice(0, 10);
-                console.log("Today\'s date: ",dateToday);
-                // grab the list of branches then iterate through the list checking for the difference in days
-                const branchList = await github.rest.repos.listBranches({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    protected: false
-                  })
-
-                const filteredBranches = branchList.data.filter( (branch) => {
-                  const branchDate = /^UTC-nightly-tests-\d{4}-\d{2}-\d{2}$/g.exec(branch.name)
-                  return branchDate != null  // skips if regex fails (is successful if matches with UTC-nightly-test branch format)
-                })
-
-                let branchesToDelete = []
-                
-                for (let i = 0; i < filteredBranches.length; i++) {
-                    const branchName = filteredBranches.at(i).name
-                    const branchDate = /\d{4}-\d{1,2}-\d{1,2}/g.exec(branchName)
-                    if (dateDifference(dateToday, branchDate[0]) >= daysThreshold) { // only happens if difference is greater than or equal to 3, we only want to keep the last 3 night branches
-                      branchesToDelete.push(branchName)
-                    }
-                }
-                
-                console.log("branches to be deleted: " + branchesToDelete)
-
-                for (let i = 0; i < branchesToDelete.length; i++) {
-                  const resp = await github.rest.git.deleteRef({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      ref: "heads/" + branchesToDelete[i],
-                    })
-                  if (resp.status == "422"){
-                      console.error("Branch doesn\'t exist")
-                  } else{
-                    console.log("Deleted branch: " + branchesToDelete[i])
-                  } 
-                }
-            }
-          
-            branchSweeper(DAYS_THRESHOLD)

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -10,10 +10,10 @@ on:
         dayThreshold:
           default: '3'
     schedule:
-        - cron: '0 4 * * *' # UTC 4AM (-7)-> 9PM PST
+        - cron: '0 3 * * *' # UTC 3AM (-7)-> 8PM PST
 
 jobs:
-  nigthly-test-branch-creation:
+  nightly-test-branch-creation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -10,7 +10,7 @@ on:
         dayThreshold:
           default: '3'
     schedule:
-        - cron: '0 3 * * *' # UTC 3AM (-7)-> 8PM PST
+        - cron: '0 3 * * *' # 3AM UTC (-7)-> 8PM PST # teamcity builds are triggered @ 4AM UTC
 
 jobs:
   nightly-test-branch-creation:

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -29,14 +29,15 @@ jobs:
                     ref: "heads/main"
                   })
                   const branchName = "UTC-" + dateToday;
+                  const commitHash = mainRef.data.object.sha;
                   try{
                   await github.rest.git.createRef({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     ref: "refs/heads/" + branchName,
-                    sha: mainRef.data.object.sha
+                    sha: commitHash
                   })
                   } catch (error){
                     core.setFailed(error + "- Failed to create new branch to be used running tonight\'s tests; branch with name " + branchName + " already exists")
                   }
-                  console.log("Created Branch: " + branchName)
+                  console.log("Created Branch: " + branchName + " using commit " + commitHash + " from main.")


### PR DESCRIPTION
Continuation of https://github.com/hashicorp/terraform-provider-google/pull/18241

An issue with TeamCity unable to perform updates on branchFilter spec resulted in the date itself not matching the nightly test branch created.

This is resolved with using a static branch filter (`+:UTC-*`) within teamcity configs. To make this work we'll create a branch such as `UTC-2024-06-24` for use by TeamCity to run the nightly test. Once a considerable period of time has passed, a cronjob will trigger that renames the `UTC-2024-06-24` -> `UTC-nightly-tests-2024-06-24`. The renaming is just for Github and allows us to only focus on one branch which must match both `+:UTC-*` and `-:UTC-nightly-tests-*`

The update to the TeamCity branchFilter spec can be seen here: https://github.com/GoogleCloudPlatform/magic-modules/pull/10785

Example run of the new workflows:
[teamcity-nightly-workflow.yaml](https://github.com/BBBmau/terraform-provider-google/actions/workflows/teamcity-nightly-workflow.yaml)

[teamcity-nightly-sweeper.yaml](https://github.com/BBBmau/terraform-provider-google/actions/workflows/teamcity-nightly-sweeper.yaml)