### PR TITLE
Fix a typo in pubsub_subscription web manual page

### DIFF
--- a/website/docs/r/pubsub_subscription.html.markdown
+++ b/website/docs/r/pubsub_subscription.html.markdown
@@ -615,7 +615,7 @@ The following arguments are supported:
 
 * `table` -
   (Required)
-  The name of the table to which to write data, of the form {projectId}:{datasetId}.{tableId}
+  The name of the table to which to write data, of the form {projectId}.{datasetId}.{tableId}
 
 * `use_topic_schema` -
   (Optional)


### PR DESCRIPTION
Fix that the field `bigquery_config.table` should be of format `{project}.${dataset}.${table}`, not `${project}:${dataset}.${table}`.