### PR TITLE
Add missing quota in bigtable_authorized_view example

### DIFF
--- a/website/docs/r/bigtable_authorized_view.html.markdown
+++ b/website/docs/r/bigtable_authorized_view.html.markdown
@@ -64,7 +64,7 @@ resource "google_bigtable_authorized_view" "authorized_view" {
   }
 
   subset_view {
-    row_prefixes = [base64encode("prefix#)]
+    row_prefixes = [base64encode("prefix#")]
 
     family_subsets {
       family_name = "family-first"


### PR DESCRIPTION
This PR adds missing quota in the `bigtable_authorized_view` example.