### PR TITLE
Use correct self_link in example for private IP example

### DIFF
--- a/website/docs/r/sql_database_instance.html.markdown
+++ b/website/docs/r/sql_database_instance.html.markdown
@@ -145,7 +145,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
     ip_configuration {
       ipv4_enabled                                  = false
-      private_network                               = google_compute_network.private_network.id
+      private_network                               = google_compute_network.private_network.self_link
       enable_private_path_for_google_cloud_services = true
     }
   }


### PR DESCRIPTION
Resubmitting PR https://github.com/hashicorp/terraform-provider-google/pull/6993 after updating branch. Hopefully this won't just be closed in 4 years without being merged.

`google_compute_network.private_network.id` isn't a valid network name for `private_network`, it needs to be a `self_link`. This updates the docs to reflect that.