### PR TITLE
Docs: Add ingress_from documentation for VPC Service Controls resources for using networks as an incoming source.

### DIFF
--- a/website/docs/r/access_context_manager_service_perimeter.html.markdown
+++ b/website/docs/r/access_context_manager_service_perimeter.html.markdown
@@ -416,7 +416,10 @@ The following arguments are supported:
   (Optional)
   A Google Cloud resource that is allowed to ingress the perimeter.
   Requests from these resources will be allowed to access perimeter data.
-  Currently only projects are allowed. Format `projects/{project_number}`
+  Currently only projects and VPCs are allowed.
+  Project format: `projects/{projectNumber}`
+  VPC network format: 
+  `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`.
   The project may be in any Google Cloud organization, not just the
   organization that the perimeter is defined in. `*` is not allowed, the case
   of allowing all Google Cloud resources only is not supported.

--- a/website/docs/r/access_context_manager_service_perimeter_ingress_policy.html.markdown
+++ b/website/docs/r/access_context_manager_service_perimeter_ingress_policy.html.markdown
@@ -146,7 +146,10 @@ The following arguments are supported:
   (Optional)
   A Google Cloud resource that is allowed to ingress the perimeter.
   Requests from these resources will be allowed to access perimeter data.
-  Currently only projects are allowed. Format `projects/{project_number}`
+  Currently only projects and VPCs are allowed.
+  Project format: `projects/{projectNumber}`
+  VPC network format: 
+  `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`.
   The project may be in any Google Cloud organization, not just the
   organization that the perimeter is defined in. `*` is not allowed, the case
   of allowing all Google Cloud resources only is not supported.


### PR DESCRIPTION
This change addresses the issue at https://github.com/hashicorp/terraform-provider-google/issues/18142.

I could not find `access_context_manager_service_perimeter.html.markdown` file in `magic-modules/mmv1/third_party/terraform/website/docs/r`.