### PR TITLE
[#19096] limit filter byte size in subscription

### DIFF
--- a/google/services/pubsub/resource_pubsub_subscription.go
+++ b/google/services/pubsub/resource_pubsub_subscription.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/verify"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -352,9 +353,10 @@ Example - "3.5s".`,
 				},
 			},
 			"filter": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidateRegexp("^.{1,256}$"),
 				Description: `The subscription only delivers the messages that match the filter.
 Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages
 by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription,


### PR DESCRIPTION
This PR limits the size of the subscription filter to 256 bytes