### PR TITLE
Remove quotes for numbers in the list

### DIFF
--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -59,7 +59,7 @@ resource "google_compute_firewall" "default" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["web"]
@@ -81,7 +81,7 @@ resource "google_compute_firewall" "rules" {
 
   allow {
     protocol  = "tcp"
-    ports     = ["80", "8080", "1000-2000"]
+    ports     = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["foo"]
@@ -242,7 +242,7 @@ If logging is enabled, logs will be exported to Stackdriver. Deprecated in favor
   is only applicable for UDP or TCP protocol. Each entry must be
   either an integer or a range. If not specified, this rule
   applies to connections through any port.
-  Example inputs include: ["22"], ["80","443"], and
+  Example inputs include: [22], [80,443], and
   ["12345-12349"].
 
 <a name="nested_deny"></a>The `deny` block supports:
@@ -260,7 +260,7 @@ If logging is enabled, logs will be exported to Stackdriver. Deprecated in favor
   is only applicable for UDP or TCP protocol. Each entry must be
   either an integer or a range. If not specified, this rule
   applies to connections through any port.
-  Example inputs include: ["22"], ["80","443"], and
+  Example inputs include: [22], [80,443], and
   ["12345-12349"].
 
 <a name="nested_log_config"></a>The `log_config` block supports:

--- a/website/docs/r/compute_firewall.html.markdown
+++ b/website/docs/r/compute_firewall.html.markdown
@@ -242,7 +242,7 @@ If logging is enabled, logs will be exported to Stackdriver. Deprecated in favor
   is only applicable for UDP or TCP protocol. Each entry must be
   either an integer or a range. If not specified, this rule
   applies to connections through any port.
-  Example inputs include: [22], [80,443], and
+  Example inputs include: [22], [80, 443], and
   ["12345-12349"].
 
 <a name="nested_deny"></a>The `deny` block supports:
@@ -260,7 +260,7 @@ If logging is enabled, logs will be exported to Stackdriver. Deprecated in favor
   is only applicable for UDP or TCP protocol. Each entry must be
   either an integer or a range. If not specified, this rule
   applies to connections through any port.
-  Example inputs include: [22], [80,443], and
+  Example inputs include: [22], [80, 443], and
   ["12345-12349"].
 
 <a name="nested_log_config"></a>The `log_config` block supports:


### PR DESCRIPTION
This is a cosmetic change to reflect more appropriately Terraform [type list](https://developer.hashicorp.com/terraform/language/expressions/types#lists-tuples)

```diff
+ ports = [80, 8080, "1000-2000"]
- ports = ["80", "8080", "1000-2000"]
```

`terraform apply`
```terraform
# google_compute_firewall.web will be created
+ resource "google_compute_firewall" "web" {
    + creation_timestamp = (known after apply)
    + description        = "Web"
    + destination_ranges = (known after apply)
    + direction          = (known after apply)
    + enable_logging     = (known after apply)
    + id                 = (known after apply)
    + name               = "allow-web"
    + network            = "default"
    + priority           = 100
    + project            = "project"
    + self_link          = (known after apply)
    + source_ranges      = [
        + "0.0.0.0/0",
      ]

    + allow {
        + ports    = [
            + "80",
          ]
        + protocol = "tcp"
      }
  }
```
