### PR TITLE
fix: Match all whitespace and non-whitespace for Pub/Sub subscription filter validation

### DIFF
--- a/google/services/pubsub/resource_pubsub_subscription.go
+++ b/google/services/pubsub/resource_pubsub_subscription.go
@@ -366,7 +366,7 @@ Example - "3.5s".`,
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: verify.ValidateRegexp(`^.{0,256}$`),
+				ValidateFunc: verify.ValidateRegexp(`^[\s\S]{0,256}$`),
 				Description: `The subscription only delivers the messages that match the filter.
 Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages
 by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription,


### PR DESCRIPTION
This change the regular expression validation for Pub/Sub subscriptions to use `[\s\S]` instead of `.` when matching characters to match both whitespace and non-whitespace characters. Because we allow empty filters (see [this issue](https://github.com/hashicorp/terraform-provider-google/issues/19269)), having only whitespace characters (which would be matched by this filter) is valid as well.

This fixes #19296.