### PR TITLE
Fix whitespace diffs on logging_sink exclusion filters

### DIFF
--- a/google/services/logging/resource_logging_sink.go
+++ b/google/services/logging/resource_logging_sink.go
@@ -65,9 +65,10 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 						Description: `A description of this exclusion.`,
 					},
 					"filter": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
+						Type:             schema.TypeString,
+						Required:         true,
+						DiffSuppressFunc: OptionalSurroundingSpacesSuppress,
+						Description:      `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
 					},
 					"disabled": {
 						Type:        schema.TypeBool,


### PR DESCRIPTION
The top-level `filter` resource already has `OptionalSurroundingSpacesSuppress`, but the filter on `exclusions` does not causing unnecessary diffs when there only difference is leading/trailing whitespace, common because of the use of HEREDOC on this attribute.