### PR TITLE
docs: remove duplicate nested_ocr_parsing_config block

### DIFF
--- a/website/docs/r/discovery_engine_data_store.html.markdown
+++ b/website/docs/r/discovery_engine_data_store.html.markdown
@@ -233,12 +233,6 @@ The following arguments are supported:
   Configurations applied to layout parser.
 
 
-<a name="nested_ocr_parsing_config"></a>The `ocr_parsing_config` block supports:
-
-* `use_native_text` -
-  (Optional)
-  If true, will use native text instead of OCR text on pages containing native text.
-
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:


### PR DESCRIPTION
- the `ocr_parsing_config` block appears twice in the documentation for the `google_discovery_engine_data_store` resource

![image](https://github.com/user-attachments/assets/493914ce-d78f-43fe-8ec1-5ec415769096)
