### PR TITLE
add docs about reserved labels of cluster labels

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -890,8 +890,8 @@ gvnic {
 * `image_type` - (Optional) The image type to use for this node. Note that changing the image type
     will delete and recreate all nodes in the node pool.
 
-* `labels` - (Optional) The Kubernetes labels (key/value pairs) to be applied to each node. The kubernetes.io/ and k8s.io/ prefixes are
-    reserved by Kubernetes Core components and cannot be specified.
+* `labels` - (Optional) The Kubernetes labels (key/value pairs) to be applied to each node. The kubernetes.io/ k8s.io/ and cloud.google.com/ prefixes are
+    reserved by Kubernetes/GKE Core components and cannot be specified.
 
 * `resource_labels` - (Optional) The GCP labels (key/value pairs) to be applied to each node. Refer [here](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels)
     for how these labels are applied to clusters, node pools and nodes.


### PR DESCRIPTION
add docs about limitation of cluster labels

Background:
When I add custom compute class, I have to add node label llike
`Node label: cloud.google.com/compute-class=COMPUTE_CLASS`
https://cloud.google.com/kubernetes-engine/docs/concepts/about-custom-compute-classes#manual-node-pools

Plan didn't show any errors, but when I apply it I recognized it reserved.
> │ Error: googleapi: Error 400: Node labels with key "[cloud.google.com/compute-class](http://cloud.google.com/compute-class)" are managed by GKE or Kubernetes and must not be manually specified.

I think this implement make sense, but it should written in docs.