### PR TITLE
Schedule daily run for backfill labeler

### DIFF
--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -32,6 +32,8 @@ jobs:
     - name: Run backfill
       env:
         GITHUB_TOKEN: ${{github.token}}
+        SINCE: ${{ inputs.since || '1973-01-01' }}
+        DRY_RUN: ${{ contains(inputs.dry_run, 'true') }}
       run: |
         cd repo/tools/issue-labeler
-        go run . -backfill-date=${{inputs.since}} -backfill-dry-run=${{inputs.dry_run}} -logtostderr=true
+        go run . -backfill-date=${{env.SINCE}} -backfill-dry-run=${{env.DRY_RUN}} -logtostderr=true

--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -13,6 +13,8 @@ on:
       dry_run:
         description: "Dry run (no changes will be made to issues)"
         type: boolean
+  schedule:
+        - cron: '0 7 * * *' # UTC 7AM (-7)-> 12AM PST
 
 jobs:
   backfill-tickets:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,8 @@ name: Issue Opened Triage
 on:
   issues:
     types: [opened]
+  schedule:
+        - cron: '0 7 * * *' # UTC 7AM (-7)-> 12AM PST
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,8 +3,6 @@ name: Issue Opened Triage
 on:
   issues:
     types: [opened]
-  schedule:
-        - cron: '0 7 * * *' # UTC 7AM (-7)-> 12AM PST
 
 jobs:
   triage:


### PR DESCRIPTION
This fixes https://github.com/hashicorp/terraform-provider-google/issues/19888

The approach of handling defaults for input parameters in schedule GHA is inspired by https://stackoverflow.com/questions/72539900/schedule-trigger-github-action-workflow-with-input-parameters