### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*                 @hashicorp/tf-eco-hybrid-cloud


### PR DESCRIPTION
Currently we [assign PR review via a GHA](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/workflows/pull-request-reviewer.yml) that picks someone from[ a list of reviewers](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/reviewer-lottery.yml). This allows reviewers to be assigned randomly despite being a mix of HashiCorp and Google employees.

This PR adds a CODEOWNERs file to see how it interacts with the system above. If it doesn't work out we can seek an exemption from being required to have a CODEOWNERs file.