### PR TITLE
Documentation Update: Revise Text Styling

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -719,7 +719,7 @@ maintenance_policy {
 
 
 <a name="nested_exclusion_options"></a>The `exclusion_options` block supports:
-* `scope` - (Required) The scope of automatic upgrades to restrict in the exclusion window. One of: **NO_UPGRADES | NO_MINOR_UPGRADES | NO_MINOR_OR_NODE_UPGRADES**
+* `scope` - (Required) The scope of automatic upgrades to restrict in the exclusion window. One of: `NO_UPGRADES`, `NO_MINOR_UPGRADES`, or `NO_MINOR_OR_NODE_UPGRADES`
 
 Specify `start_time` and `end_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) "Zulu" date format.  The start time's date is
 the initial date that the window starts, and the end time is used for calculating duration.Specify `recurrence` in


### PR DESCRIPTION
I came across this in the Terraform documentation, and it struck me as rather bold:

<img width="635" alt="image" src="https://github.com/user-attachments/assets/d5231dfe-4a1a-4646-b45c-0c57e3eb8e28">
