### PR TITLE
Clarify `google_storage_bucket` `response_header` in `storage_bucket.html.markdown`

### DIFF
--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -241,7 +241,7 @@ The following arguments are supported:
 
 * `method` - (Optional) The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc) Note: "*" is permitted in the list of methods, and means "any method".
 
-* `response_header` - (Optional) The list of HTTP headers other than the [simple response headers](https://www.w3.org/TR/cors/#simple-response-header) to give permission for the user-agent to share across domains.
+* `response_header` - (Optional) The list of HTTP headers to give permission for the user-agent to share across domains. A typical example would e.g. be allowing the `Content-Type` header.
 
 * `max_age_seconds` - (Optional) The value, in seconds, to return in the [Access-Control-Max-Age header](https://www.w3.org/TR/cors/#access-control-max-age-response-header) used in preflight responses.
 


### PR DESCRIPTION
The description of `response_header` prior to this change seemed to suggest that simple response headers were always implicitly included in  the `response_header` list. However, the link to the fetch standard on simple response headers was broken, and searching for the term "simple response" doesn't yield the result. [According to MDN](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header), the `Content-Type` would be considered such a simple response header. However on my bucket, preflight requests on a bucket failed until `response_header` was set to `["Content-Type"]`, countering the docs. The wrong docs cost me hours, until I finally decided to go try adding going with code analogous to the [basic CORS example configuration](https://cloud.google.com/storage/docs/cors-configurations). Now my assumption is that at least `Content-Type` is not automatically returned in responses to cross origin preflight requests, and - since this header supposedly is a simple response header - none of those is automatically returned. This PR updates the documentation accordingly, removing the claim that simple response headers are always included, and instead adds the relatively common example of the `Content-Type` header.