### PR TITLE
Fix TestAccDataprocCluster_withNetworkRefs

### DIFF
--- a/google/services/dataproc/resource_dataproc_cluster_test.go
+++ b/google/services/dataproc/resource_dataproc_cluster_test.go
@@ -2388,6 +2388,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
 
     gce_cluster_config {
       network = google_compute_network.dataproc_network.self_link
+      internal_ip_only = false
     }
   }
 }


### PR DESCRIPTION
Dataproc doesn't allow cluster creation when `internal_ip_only` is set to `true` and Private Google Access is not enabled on the subnet. Since the subnetwork in this test is auto created, it does not have Private google access. Setting `internal_ip_only` to `false` to fix the test.

Fixes: #20254 