### PR TITLE
Update org_policy_policy documentation to make resource definition clearer

### DIFF
--- a/website/docs/r/org_policy_policy.html.markdown
+++ b/website/docs/r/org_policy_policy.html.markdown
@@ -34,8 +34,8 @@ To get more information about Policy, see:
 
 ```hcl
 resource "google_org_policy_policy" "primary" {
-  name   = "projects/${google_project.basic.name}/policies/iam.disableServiceAccountKeyUpload"
-  parent = "projects/${google_project.basic.name}"
+  name   = "projects/${google_project.basic.project_id}/policies/iam.disableServiceAccountKeyUpload"
+  parent = "projects/${google_project.basic.project_id}"
 
   spec {
     rules {
@@ -92,8 +92,8 @@ resource "google_org_policy_policy" "primary" {
 
 ```hcl
 resource "google_org_policy_policy" "primary" {
-  name   = "projects/${google_project.basic.name}/policies/gcp.resourceLocations"
-  parent = "projects/${google_project.basic.name}"
+  name   = "projects/${google_project.basic.project_id}/policies/gcp.resourceLocations"
+  parent = "projects/${google_project.basic.project_id}"
 
   spec {
     rules {


### PR DESCRIPTION
This PR:
- Updates the documentation to make it explicit that what is required for the resource definition is the project id, not the project name.

The project name may differ from the project id in google. For example, you may have a project ID `sandbox-123123` while the project name is `sandbox`. If in this case using the project name the role creation will fail.