### PR TITLE
`scripts`: add `ephemeral-resources` in `scripts/docscheck.sh`

### DIFF
--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -36,10 +36,19 @@ for doc in $docs; do
       fi
       ;;
 
+    "ephemeral-resources")
+      # Ephemeral Resources require a page_title
+      grep "^page_title: " "$doc" > /dev/null
+      if [[ "$?" == "1" ]]; then
+        echo "Doc is missing a page_title: $doc"
+        error=true
+      fi
+      ;;
+
     *)
       error=true
       echo "Unknown category \"$category\". " \
-        "Docs can only exist in r/, d/, or guides/ folders."
+        "Docs can only exist in r/, d/, ephemeral-resources/, functions/ or guides/ folders."
       ;;
   esac
 done


### PR DESCRIPTION
Necessary for CI to pass on future PRs due to the introduction of ephemeral-resources.

GHA error can be found here: https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/12126681971/job/33809291178?pr=12469