### PR TITLE
`teamcity-nightly-workflow`: only create nightly-test branch on upstream provider repo

### DIFF
--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   rename-TC-nightly-branch:
-    if: github.repository == 'hashicorp/terraform-provider-google'
+    if: github.repository == 'hashicorp/terraform-provider-google' || github.repository == 'hashicorp/terraform-provider-google-beta'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   rename-TC-nightly-branch:
-
+    if: github.repository == 'hashicorp/terraform-provider-google'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0


### PR DESCRIPTION
prevents `nightly-test` branch from being created on forked repos since they are only used on upstream terraform-provider-google