### PR TITLE
Fix hierarchical_namespace example

### DIFF
--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -111,7 +111,7 @@ resource "google_storage_bucket" "auto-expire" {
   location      = "US"
   force_destroy = true
 
-  hierarchical_namespace = {
+  hierarchical_namespace {
     enabled = true
   }
 }


### PR DESCRIPTION
hierarchical_namespace is a block.

Got this error when trying out the example:

```
│ Error: Unsupported argument
│ 
│   on main.tf line 162, in resource "google_storage_bucket" "default":
│  162:   hierarchical_namespace = {
│ 
│ An argument named "hierarchical_namespace" is not expected here. Did you
│ mean to define a block of type "hierarchical_namespace"?
```

Kudos to @jbuck for telling me that this is a docs issue.