### PR TITLE
Add the release note for the skipped commit

### DIFF
--- a/.changelog/13222.txt
+++ b/.changelog/13222.txt
@@ -1,3 +1,6 @@
 ```release-note:none
 upgrade google.golang.org/api to v0.223.0
 ```
+```release-note:enhancement
+workflows: added `execution_history_level` field to `google_workflows_workflow` resource
+```


### PR DESCRIPTION
Add the release note for the skipped commit, which is included in https://github.com/hashicorp/terraform-provider-google/pull/21782