### PR TITLE
Netapp volume documentation correction

### DIFF
--- a/google/services/netapp/resource_netapp_volume.go
+++ b/google/services/netapp/resource_netapp_volume.go
@@ -245,7 +245,7 @@ Only the volume with largeCapacity will be allowed to have multiple endpoints.`,
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							Description: `Full name of the snapshot to use for creating this volume.
+							Description: `Full name of the backup to use for creating this volume.
 'source_snapshot' and 'source_backup' cannot be used simultaneously.
 Format: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backupVaultId}}/backups/{{backup}}'.`,
 							ExactlyOneOf: []string{"restore_parameters.0.source_backup", "restore_parameters.0.source_snapshot"},

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -249,7 +249,7 @@ Possible values: DEFAULT, FORCE.
 
 * `source_backup` -
   (Optional)
-  Full name of the snapshot to use for creating this volume.
+  Full name of the backup to use for creating this volume.
   `source_snapshot` and `source_backup` cannot be used simultaneously.
   Format: `projects/{{project}}/locations/{{location}}/backupVaults/{{backupVaultId}}/backups/{{backup}}`.
 


### PR DESCRIPTION
Documentation for "restore_parameters" contains an error - it describes both source_snapshot and source_backup as "Full name of the snapshot to use..." - this corrects that to "backup" where applicable.