### PR TITLE
Allow serial-port-logging-enable to be provided for google_workbench_instance metadata

### DIFF
--- a/google/services/workbench/resource_workbench_instance.go
+++ b/google/services/workbench/resource_workbench_instance.go
@@ -106,7 +106,6 @@ var WorkbenchInstanceProvidedMetadata = []string{
 	"report-system-status",
 	"resource-url",
 	"restriction",
-	"serial-port-logging-enable",
 	"service-account-mode",
 	"shutdown-script",
 	"title",


### PR DESCRIPTION
Fixes #22381 