### PR TITLE
Use the correct form of `sha256.Sum256`.

### DIFF
--- a/google/services/compute/resource_compute_region_ssl_certificate.go
+++ b/google/services/compute/resource_compute_region_ssl_certificate.go
@@ -40,7 +40,8 @@ import (
 // sha256DiffSuppress
 // if old is the hex-encoded sha256 sum of new, treat them as equal
 func sha256DiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	return hex.EncodeToString(sha256.New().Sum([]byte(old))) == new
+	h := sha256.Sum256([]byte(old))
+	return hex.EncodeToString(h[:]) == new
 }
 
 func ResourceComputeRegionSslCertificate() *schema.Resource {


### PR DESCRIPTION
`sha256.New().Sum(foo)` appends the SHA-256 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk