### PR TITLE
Add private_registry_config to VMware user and admin cluster resources.

### DIFF
--- a/google/services/gkeonprem/resource_gkeonprem_vmware_cluster.go
+++ b/google/services/gkeonprem/resource_gkeonprem_vmware_cluster.go
@@ -268,6 +268,27 @@ full access to the cluster.`,
 				Optional:    true,
 				Description: `Enable advanced cluster. Default to false.`,
 			},
+			"private_registry_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Configuration for private registry.`,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ca_cert": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: `Contains the CA certificate public key for private registry.`,
+						},
+						"address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: `The registry address.`,
+						},
+				}
+			},
 			"enable_control_plane_v2": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -1007,6 +1028,12 @@ func resourceGkeonpremVmwareClusterCreate(d *schema.ResourceData, meta interface
 	} else if v, ok := d.GetOkExists("enable_advanced_cluster"); !tpgresource.IsEmptyValue(reflect.ValueOf(enableAdvancedClusterProp)) && (ok || !reflect.DeepEqual(v, enableAdvancedClusterProp)) {
 		obj["enableAdvancedCluster"] = enableAdvancedClusterProp
 	}
+	privateRegistryConfigProp, err := expandGkeonpremVmwareClusterPrivateRegistry(d.Get("private_registry_config"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("private_registry_config"); !tpgresource.IsEmptyValue(reflect.ValueOf(privateRegistryConfigProp)) && (ok || !reflect.DeepEqual(v, privateRegistryConfigProp)) {
+		obj["privateRegistryConfigProp"] = privateRegistryConfigProp
+	}
 	disableBundledIngressProp, err := expandGkeonpremVmwareClusterDisableBundledIngress(d.Get("disable_bundled_ingress"), d, config)
 	if err != nil {
 		return err
@@ -1185,6 +1212,9 @@ func resourceGkeonpremVmwareClusterRead(d *schema.ResourceData, meta interface{}
 	if err := d.Set("enable_advanced_cluster", flattenGkeonpremVmwareClusterEnableAdvancedCluster(res["enableAdvancedCluster"], d, config)); err != nil {
 		return fmt.Errorf("Error reading VmwareCluster: %s", err)
 	}
+        if err := d.Set("private_registry_config", flattenGkeonpremVmwareClusterPrivateRegistryConfig(res["privateRegistryConfig"], d, config)); err != nil {
+		return fmt.Errorf("Error reading VmwareCluster: %s", err)
+	}
 	if err := d.Set("disable_bundled_ingress", flattenGkeonpremVmwareClusterDisableBundledIngress(res["disableBundledIngress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading VmwareCluster: %s", err)
 	}
@@ -1328,6 +1358,12 @@ func resourceGkeonpremVmwareClusterUpdate(d *schema.ResourceData, meta interface
 	} else if v, ok := d.GetOkExists("enable_advanced_cluster"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, enableAdvancedClusterProp)) {
 		obj["enableAdvancedCluster"] = enableAdvancedClusterProp
 	}
+	privateRegistryConfig, err := expandGkeonpremVmwareClusterprivateRegistryConfig(d.Get("private_registry_config"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("private_registry_config"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, privateRegistryConfigProp)) {
+		obj["privateRegistryConfig"] = privateRegistryConfig
+	}
 	disableBundledIngressProp, err := expandGkeonpremVmwareClusterDisableBundledIngress(d.Get("disable_bundled_ingress"), d, config)
 	if err != nil {
 		return err
@@ -1412,6 +1448,10 @@ func resourceGkeonpremVmwareClusterUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("enable_advanced_cluster") {
 		updateMask = append(updateMask, "enableAdvancedCluster")
+	}
+
+	if d.HasChange("private_registry_config") {
+		updateMask = append(updateMask, "privateRegistryConfig")
 	}
 
 	if d.HasChange("disable_bundled_ingress") {
@@ -2315,6 +2355,10 @@ func flattenGkeonpremVmwareClusterEnableControlPlaneV2(v interface{}, d *schema.
 }
 
 func flattenGkeonpremVmwareClusterEnableAdvancedCluster(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenGkeonpremVmwareClusterPrivateRegistryConfig(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
 
@@ -3403,6 +3447,10 @@ func expandGkeonpremVmwareClusterEnableControlPlaneV2(v interface{}, d tpgresour
 }
 
 func expandGkeonpremVmwareClusterEnableAdvancedCluster(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandGkeonpremVmwareClusterPrivateRegistryConfig(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google/services/gkeonprem/resource_gkeonprem_vmware_cluster_generated_meta.yaml
+++ b/google/services/gkeonprem/resource_gkeonprem_vmware_cluster_generated_meta.yaml
@@ -26,6 +26,7 @@ fields:
   - field: 'effective_annotations'
     provider_only: true
   - field: 'enable_advanced_cluster'
+  - field: 'private_registry_config'
   - field: 'enable_control_plane_v2'
   - field: 'endpoint'
   - field: 'etag'

--- a/google/services/gkeonprem/resource_gkeonprem_vmware_cluster_generated_test.go
+++ b/google/services/gkeonprem/resource_gkeonprem_vmware_cluster_generated_test.go
@@ -300,6 +300,10 @@ resource "google_gkeonprem_vmware_cluster" "cluster-manuallb" {
   vm_tracking_enabled = true
   enable_control_plane_v2 = true
   enable_advanced_cluster = true
+  private_registry_config = {
+    address = "test-address"
+    ca_cert = "test-ca-cert"
+  }
   upgrade_policy {
     control_plane_only = true
   }

--- a/google/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go
+++ b/google/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go
@@ -374,6 +374,10 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLbStart(context map[
     vm_tracking_enabled = true
     enable_control_plane_v2 = true
     enable_advanced_cluster = true
+    private_registry_config = {
+      address = "test-address"
+      ca_cert = "test-ca-cert"
+    }
     disable_bundled_ingress = true
     upgrade_policy {
       control_plane_only = true

--- a/website/docs/r/gkeonprem_vmware_admin_cluster.html.markdown
+++ b/website/docs/r/gkeonprem_vmware_admin_cluster.html.markdown
@@ -781,6 +781,9 @@ In addition to the arguments listed above, the following computed attributes are
 * `enable_advanced_cluster` -
   If set, the advanced cluster feature is enabled.
 
+* `private_registry_config` -
+  User can use this field to set customized private registry.
+
 * `effective_annotations` -
   All of annotations (key/value pairs) present on the resource in GCP, including the annotations configured through Terraform, other clients and services.
 


### PR DESCRIPTION
gkeonprem: added `private_registry_config` field to `google_gkeonprem_vmware_admin_cluster` resource