### PR TITLE
doc: fix expample in data google_artifact_registry_package

### DIFF
--- a/website/docs/d/artifact_registry_package.html.markdown
+++ b/website/docs/d/artifact_registry_package.html.markdown
@@ -24,9 +24,10 @@ This data source fetches information of a package from a provided Artifact Regis
 ## Example Usage
 
 ```hcl
-resource "google_artifact_registry_package" "my_package" {
+data "google_artifact_registry_package" "my_package" {
   location      = "us-west1"
   repository_id = "my-repository"
+  name          = "app"
 }
 ```
 


### PR DESCRIPTION
We have a data source that shows an example for a resource. I assume there was a simple oversight.