### PR TITLE
`goreleaser`: disable `docker_digest`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ archives:
         dst: 'LICENSE.txt'
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+docker_digest:
+  disable: true
 builds:
   - # Special binary naming is only necessary for Terraform CLI 0.12
     binary: '{{ .ProjectName }}_v{{ .Version }}_x5'


### PR DESCRIPTION
resolves the goreleaser failure that was introduced in `2.12.0` of the goreleaser that was introduced yesterday
- https://github.com/goreleaser/goreleaser/releases/tag/v2.12.0
