### PR TITLE
Sync diffs in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: lint testnolint
 testnolint:
 	go test $(TESTARGS) -timeout=30s $(TEST)
 
-testacc:
+testacc: lint
 	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
 
 fmt:


### PR DESCRIPTION
Saw that there were slightly different settings- make them the same. I picked some settings from one, and some from the other, so there are two PRs. Beta: https://github.com/hashicorp/terraform-provider-google-beta/pull/10721