### PR TITLE
Backport bigtable IAM change

### DIFF
--- a/google/services/bigtable/iam_bigtable_table.go
+++ b/google/services/bigtable/iam_bigtable_table.go
@@ -33,6 +33,7 @@ var IamBigtableTableSchema = map[string]*schema.Schema{
 	"instance": {
 		Type:         schema.TypeString,
 		Optional:     true,
+		Computed:     true,
 		ForceNew:     true,
 		ExactlyOneOf: []string{"instance", "instance_name"},
 		Deprecated:   "`instance` is deprecated in favor of `instance_name`",
@@ -40,6 +41,7 @@ var IamBigtableTableSchema = map[string]*schema.Schema{
 	"instance_name": {
 		Type:         schema.TypeString,
 		Optional:     true,
+		Computed:     true,
 		ForceNew:     true,
 		ExactlyOneOf: []string{"instance", "instance_name"},
 	},
@@ -75,10 +77,23 @@ func NewBigtableTableUpdater(d tpgresource.TerraformResourceData, config *transp
 		return nil, fmt.Errorf("Error setting project: %s", err)
 	}
 
+	instance := d.Get("instance").(string)
+	if instance == "" {
+		instance = d.Get("instance_name").(string)
+	}
+
+	if err := d.Set("instance", ins); err != nil {
+		return nil, fmt.Errorf("Error setting instance: %s", err)
+	}
+
+	if err := d.Set("instance_name", ins); err != nil {
+		return nil, fmt.Errorf("Error setting instance_name: %s", err)
+	}
+
 	return &BigtableTableIamUpdater{
 		project:      project,
-		instance:     d.Get("instance").(string),
-		instanceName: d.Get("instance").(string),
+		instance:     instance,
+		instanceName: instance,
 		table:        d.Get("table").(string),
 		d:            d,
 		Config:       config,

--- a/google/services/bigtable/iam_bigtable_table.go
+++ b/google/services/bigtable/iam_bigtable_table.go
@@ -31,9 +31,17 @@ import (
 
 var IamBigtableTableSchema = map[string]*schema.Schema{
 	"instance": {
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: true,
+		Type:         schema.TypeString,
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: []string{"instance", "instance_name"},
+		Deprecated:   "`instance` is deprecated in favor of `instance_name`",
+	},
+	"instance_name": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: []string{"instance", "instance_name"},
 	},
 	"project": {
 		Type:     schema.TypeString,
@@ -49,11 +57,12 @@ var IamBigtableTableSchema = map[string]*schema.Schema{
 }
 
 type BigtableTableIamUpdater struct {
-	project  string
-	instance string
-	table    string
-	d        tpgresource.TerraformResourceData
-	Config   *transport_tpg.Config
+	project      string
+	instance     string
+	instanceName string
+	table        string
+	d            tpgresource.TerraformResourceData
+	Config       *transport_tpg.Config
 }
 
 func NewBigtableTableUpdater(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (tpgiamresource.ResourceIamUpdater, error) {
@@ -67,11 +76,12 @@ func NewBigtableTableUpdater(d tpgresource.TerraformResourceData, config *transp
 	}
 
 	return &BigtableTableIamUpdater{
-		project:  project,
-		instance: d.Get("instance").(string),
-		table:    d.Get("table").(string),
-		d:        d,
-		Config:   config,
+		project:      project,
+		instance:     d.Get("instance").(string),
+		instanceName: d.Get("instance").(string),
+		table:        d.Get("table").(string),
+		d:            d,
+		Config:       config,
 	}, nil
 }
 
@@ -94,6 +104,10 @@ func BigtableTableIdParseFunc(d *schema.ResourceData, config *transport_tpg.Conf
 	}
 
 	if err := d.Set("instance", values["instance"]); err != nil {
+		return fmt.Errorf("Error setting instance: %s", err)
+	}
+
+	if err := d.Set("instance_name", values["instance"]); err != nil {
 		return fmt.Errorf("Error setting instance: %s", err)
 	}
 

--- a/google/services/bigtable/iam_bigtable_table.go
+++ b/google/services/bigtable/iam_bigtable_table.go
@@ -123,7 +123,7 @@ func BigtableTableIdParseFunc(d *schema.ResourceData, config *transport_tpg.Conf
 	}
 
 	if err := d.Set("instance_name", values["instance"]); err != nil {
-		return fmt.Errorf("Error setting instance: %s", err)
+		return fmt.Errorf("Error setting instance_name: %s", err)
 	}
 
 	if err := d.Set("table", values["table"]); err != nil {

--- a/google/services/bigtable/iam_bigtable_table.go
+++ b/google/services/bigtable/iam_bigtable_table.go
@@ -82,11 +82,11 @@ func NewBigtableTableUpdater(d tpgresource.TerraformResourceData, config *transp
 		instance = d.Get("instance_name").(string)
 	}
 
-	if err := d.Set("instance", ins); err != nil {
+	if err := d.Set("instance", instance); err != nil {
 		return nil, fmt.Errorf("Error setting instance: %s", err)
 	}
 
-	if err := d.Set("instance_name", ins); err != nil {
+	if err := d.Set("instance_name", instance); err != nil {
 		return nil, fmt.Errorf("Error setting instance_name: %s", err)
 	}
 

--- a/google/services/bigtable/resource_bigtable_table_iam_test.go
+++ b/google/services/bigtable/resource_bigtable_table_iam_test.go
@@ -122,7 +122,7 @@ func TestAccBigtableTableIamMember(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				// Test IAM Binding - Update instance to instance_name 
+				// Test IAM Binding - Update instance to instance_name
 				Config: testAccBigtableTableIamMember_updateName(instance, cluster, account, role),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(

--- a/google/services/bigtable/resource_bigtable_table_iam_test.go
+++ b/google/services/bigtable/resource_bigtable_table_iam_test.go
@@ -57,6 +57,20 @@ func TestAccBigtableTableIamBinding(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				// Test IAM Binding - Update instance to instance_name
+				Config: testAccBigtableTableIamBinding_basicUpdateName(instance, cluster, account, role),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_bigtable_table_iam_binding.binding", "role", role),
+				),
+			},
+			{
+				ResourceName:      "google_bigtable_table_iam_binding.binding",
+				ImportStateId:     importId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				// Test IAM Binding update
 				Config: testAccBigtableTableIamBinding_update(instance, cluster, account, role),
 			},
@@ -107,6 +121,38 @@ func TestAccBigtableTableIamMember(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				// Test IAM Binding - Update instance to instance_name 
+				Config: testAccBigtableTableIamMember_updateName(instance, cluster, account, role),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_bigtable_table_iam_member.member", "role", role),
+					resource.TestCheckResourceAttr(
+						"google_bigtable_table_iam_member.member", "member", "serviceAccount:"+envvar.ServiceAccountCanonicalEmail(account)),
+				),
+			},
+			{
+				ResourceName:      "google_bigtable_table_iam_member.member",
+				ImportStateId:     importId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test IAM Binding - Update instance_name to instance
+				Config: testAccBigtableTableIamMember(instance, cluster, account, role),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_bigtable_table_iam_member.member", "role", role),
+					resource.TestCheckResourceAttr(
+						"google_bigtable_table_iam_member.member", "member", "serviceAccount:"+envvar.ServiceAccountCanonicalEmail(account)),
+				),
+			},
+			{
+				ResourceName:      "google_bigtable_table_iam_member.member",
+				ImportStateId:     importId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -139,6 +185,28 @@ func TestAccBigtableTableIamPolicy(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				// Test IAM Binding - Update instance to instance_name
+				Config: testAccBigtableTableIamPolicy_updateName(instance, cluster, account, role),
+				Check:  resource.TestCheckResourceAttrSet("data.google_bigtable_table_iam_policy.policy", "policy_data"),
+			},
+			{
+				ResourceName:      "google_bigtable_table_iam_policy.policy",
+				ImportStateId:     importId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test IAM Binding - Update instance to instance_name
+				Config: testAccBigtableTableIamPolicy(instance, cluster, account, role),
+				Check:  resource.TestCheckResourceAttrSet("data.google_bigtable_table_iam_policy.policy", "policy_data"),
+			},
+			{
+				ResourceName:      "google_bigtable_table_iam_policy.policy",
+				ImportStateId:     importId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -157,6 +225,29 @@ resource "google_service_account" "test-account2" {
 
 resource "google_bigtable_table_iam_binding" "binding" {
   instance = google_bigtable_instance.instance.name
+  table    = google_bigtable_table.table.name
+  role     = "%s"
+  members  = [
+    "serviceAccount:${google_service_account.test-account1.email}",
+  ]
+}
+`, instance, cluster, cluster, account, account, role)
+}
+
+func testAccBigtableTableIamBinding_basicUpdateName(instance, cluster, account, role string) string {
+	return fmt.Sprintf(testBigtableTableIam+`
+resource "google_service_account" "test-account1" {
+  account_id   = "%s-1"
+  display_name = "Bigtable Table IAM Testing Account"
+}
+
+resource "google_service_account" "test-account2" {
+  account_id   = "%s-2"
+  display_name = "Bigtable Table Iam Testing Account"
+}
+
+resource "google_bigtable_table_iam_binding" "binding" {
+  instance_name = google_bigtable_instance.instance.name
   table    = google_bigtable_table.table.name
   role     = "%s"
   members  = [
@@ -206,6 +297,22 @@ resource "google_bigtable_table_iam_member" "member" {
 `, instance, cluster, cluster, account, role)
 }
 
+func testAccBigtableTableIamMember_updateName(instance, cluster, account, role string) string {
+	return fmt.Sprintf(testBigtableTableIam+`
+resource "google_service_account" "test-account" {
+  account_id   = "%s"
+  display_name = "Bigtable Table IAM Testing Account"
+}
+
+resource "google_bigtable_table_iam_member" "member" {
+  instance_name = google_bigtable_instance.instance.name
+  table    = google_bigtable_table.table.name
+  role     = "%s"
+  member   = "serviceAccount:${google_service_account.test-account.email}"
+}
+`, instance, cluster, cluster, account, role)
+}
+
 func testAccBigtableTableIamPolicy(instance, cluster, account, role string) string {
 	return fmt.Sprintf(testBigtableTableIam+`
 resource "google_service_account" "test-account" {
@@ -222,6 +329,34 @@ data "google_iam_policy" "policy" {
 
 resource "google_bigtable_table_iam_policy" "policy" {
   instance    = google_bigtable_instance.instance.name
+  table       = google_bigtable_table.table.name
+  policy_data = data.google_iam_policy.policy.policy_data
+}
+
+data "google_bigtable_table_iam_policy" "policy" {
+  instance_name    = google_bigtable_instance.instance.name
+  table       = google_bigtable_table.table.name
+}
+
+`, instance, cluster, cluster, account, role)
+}
+
+func testAccBigtableTableIamPolicy_updateName(instance, cluster, account, role string) string {
+	return fmt.Sprintf(testBigtableTableIam+`
+resource "google_service_account" "test-account" {
+  account_id   = "%s"
+  display_name = "Bigtable Table IAM Testing Account"
+}
+
+data "google_iam_policy" "policy" {
+  binding {
+    role    = "%s"
+    members = ["serviceAccount:${google_service_account.test-account.email}"]
+  }
+}
+
+resource "google_bigtable_table_iam_policy" "policy" {
+  instance_name    = google_bigtable_instance.instance.name
   table       = google_bigtable_table.table.name
   policy_data = data.google_iam_policy.policy.policy_data
 }


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-provider-google/issues/24397

```release-note:enhancement
bigtable: added `instance_name` field to `google_bigtable_table_iam_*` resources
```

```release-note:deprecation
bigtable: deprecated `instance` in favor of `instance_name` in `google_bigtable_table_iam_*` resources
```

```release-note:note
bigtable: It is recommended for `google_bigtable_table_iam_*` resources to upgrade to v6.50.0 and switch from `instance` to `instance_name` in your configuration before upgrading to v7.X
```