### PR TITLE
docs(google_logging_metric): Correct bucket_name reference in example

### DIFF
--- a/website/docs/r/logging_metric.html.markdown
+++ b/website/docs/r/logging_metric.html.markdown
@@ -132,7 +132,7 @@ resource "google_logging_project_bucket_config" "logging_metric" {
 resource "google_logging_metric" "logging_metric" {
   name        = "my-(custom)/metric"
   filter      = "resource.type=gae_app AND severity>=ERROR"
-  bucket_name = google_logging_project_bucket_config.logging_metric.id
+  bucket_name = google_logging_project_bucket_config.logging_metric.name
 }
 ```
 <div class = "oics-button" style="float: right; margin: 0 0 -15px">


### PR DESCRIPTION
### The Problem

The original example code for the `google_logging_metric` resource is as follows:
```terraform
resource "google_logging_project_bucket_config" "logging_metric" {
    location  = "global"
    project   = "my-project-name"
    bucket_id = "_Default"
}

resource "google_logging_metric" "logging_metric" {
  name        = "my-(custom)/metric"
  filter      = "resource.type=gae_app AND severity>=ERROR"
  bucket_name = google_logging_project_bucket_config.logging_metric.id
}
```

When using `google_logging_project_bucket_config.logging_metric.id` for the `bucket_name`, the `terraform apply` command succeeds, and the logs-based metric is created in Google Cloud. However, the metric fails to ingest any log data. As a result, it is **not visible or queryable in Metrics Explorer**, even after new logs matching the filter have been generated.

This appears to happen because while both `.id` and `.name` attributes resolve to the full resource path, only `.name` correctly links the metric to the log bucket's ingestion pipeline.

Further investigation reveals a critical difference in the values resolved by the `.id` and `.name` attributes:

`google_logging_project_bucket_config.logging_metric.id` resolves to a path containing the numeric Project ID:
`projects/1234567890/locations/global/buckets/your-bucket-id`

`google_logging_project_bucket_config.logging_metric.name` resolves to a path containing the string-based Project name:
`projects/your-project-name/locations/global/buckets/your-bucket-id`

The Google Cloud Logging API requires the resource name containing the **string-based Project name** for the `bucket_name` argument. Using the numeric ID allows the resource to be created without error, but it appears to cause a misconfiguration in the log ingestion routing, leading to the metric not receiving data.

