### PR TITLE
Update GNUmakefile to include TF_ACC_REFRESH_AFTER_APPLY=1

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,7 @@ testnolint:
 	go test $(TESTARGS) -timeout=30s $(TEST)
 
 testacc: lint
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
+	TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."


### PR DESCRIPTION
comes as part of the PR that was merged yesterday:

- https://github.com/GoogleCloudPlatform/magic-modules/pull/14923

Was under the impression that we just needed to add it in our TeamCity builds as a hidden variable but this isn't the case.