### PR TITLE
Doc: google_logging_organization_sink description grammar fix

### DIFF
--- a/website/docs/r/logging_organization_sink.html.markdown
+++ b/website/docs/r/logging_organization_sink.html.markdown
@@ -15,12 +15,12 @@
 # ----------------------------------------------------------------------------
 subcategory: "Cloud (Stackdriver) Logging"
 description: |-
-  Manages a organization-level logging sink.
+  Manages an organization-level logging sink.
 ---
 
 # google_logging_organization_sink
 
-Manages a organization-level logging sink. For more information see:
+Manages an organization-level logging sink. For more information see:
 * [API documentation](https://cloud.google.com/logging/docs/reference/v2/rest/v2/organizations.sinks)
 * How-to Guides
     * [Exporting Logs](https://cloud.google.com/logging/docs/export)


### PR DESCRIPTION
[Doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_organization_sink)

`Manages a organization-level logging sink.`
to
`Manages an organization-level logging sink.`