### PR TITLE
bucket_id uses name instead of id

### DIFF
--- a/website/docs/r/firebase_storage_bucket.html.markdown
+++ b/website/docs/r/firebase_storage_bucket.html.markdown
@@ -47,7 +47,7 @@ resource "google_storage_bucket" "default" {
 resource "google_firebase_storage_bucket" "default" {
   provider  = google-beta
   project   = "my-project-name"
-  bucket_id = google_storage_bucket.default.id
+  bucket_id = google_storage_bucket.default.name
 }
 ```
 


### PR DESCRIPTION
Spent a couple of hours to figure that `bucket_id` uses name instead of id