### PR TITLE
Add `deletion_labels` to `google_container_aws_node_pool`

### DIFF
--- a/google/services/containeraws/resource_container_aws_node_pool.go
+++ b/google/services/containeraws/resource_container_aws_node_pool.go
@@ -694,6 +694,11 @@ func resourceContainerAwsNodePoolRead(d *schema.ResourceData, meta interface{}) 
 	if err = d.Set("annotations", flattenContainerAwsNodePoolAnnotations(res.Annotations, d)); err != nil {
 		return fmt.Errorf("error setting annotations in state: %s", err)
 	}
+	// preserve user-provided deletion_labels in state
+	if v, ok := d.GetOk("deletion_labels"); ok {
+		// no API source of truth for this field; keep config value
+		_ = d.Set("deletion_labels", tpgresource.CheckStringMap(v))
+	}
 	if err = d.Set("create_time", res.CreateTime); err != nil {
 		return fmt.Errorf("error setting create_time in state: %s", err)
 	}


### PR DESCRIPTION
I know Anthos on AWS is sunsetting, and I needed this to work properly in my fork so we can use it in a custom build, but just in case someone else looking for this...

Currently, when GCP receives the request to delete Anthos on AWS nodepool - it immediately proceeds to terminate all nodes. It does not seem to use eviction API or `update_settings`.

Sometimes, deletion of the nodepool doesn't mean we are shutting down the cluster - we may be replacing a nodepool for an upgrade or other change. Meaning that there is some other replacement nodepool is ready to accept workloads, and so the nodepool must be gracefully destroyed with respect to PDBs and `update_settings`.

This PR can't change backend behavior, but it attempts to work around the problem on the client side. It is introducing a new `deletion_labels` input to the `google_container_aws_node_pool`. When provider runs deletion sequence, it will check if this is set, and if yes - before deletion, provider will now run a regular nodepool change request adding these labels.

The idea is that you may have `labels = { "nodepool" = "default" }` and this is what you are using for node selectors on the pods. If you also set `deletion_labels = { "nodepool" = "shutting-down" }`, then at deletion the operator will first do the same operation as if you changed `labels` to `{ "nodepool" = "shutting-down" }`, which is a graceful operation. It will replace all nodes respecting PDBs and `update_settings` and the nodes by the end of the operation will be empty (because no pods will have `shutting-down` in their selector).

Only then does it proceeds to actually shutting down the nodepool, which is ungracefully as always - but it doesn't matter at that point.

Obviously, this is clunky and results in bogus instances being brought up for no particular reason - but that's best I could think of as a workaround on the client side. I doubt backend for Anthos on AWS will be changing at this point. Open to better suggestions too.