### PR TITLE
`.github`: replace `hashicorp/pr-warning` with `actions/github-script`

### DIFF
--- a/.github/workflows/upstream-mm.yml
+++ b/.github/workflows/upstream-mm.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post the warning
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
This shift to using `actions/github-script` would resolve a number of security concerns in regards to `@octokit` and `@actions/core` while also letting us archive the `pr-warning` repo as a whole since the google repos are the only repos that are dependent of this action

A test run can be found on my forked google provider repo - https://github.com/BBBmau/terraform-provider-google/actions/runs/20967790261/job/60262858621