### PR TITLE
Update HashiCorp copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 HashiCorp, Inc.
+Copyright IBM Corp. 2014, 2026
 
 Mozilla Public License Version 2.0
 ==================================


### PR DESCRIPTION
This change updates copyright headers in the provider repos in the
hashicorp GitHub organization. This is consistent with all other
HashiCorp official Terraform provider repositories.

`LICENSE` appears to be a non-generated file.
