### PR TITLE
Make unit test script error on empty file or no results

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-TEST?=$$(bash scripts/get_unit_test_pkgs.sh)
+TEST?=$$(pkgs=$$(bash scripts/get_unit_test_pkgs.sh); [ -n "$$pkgs" ] && echo "$$pkgs" || { echo "Error: No test packages found"; exit 1; })
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=google
 DIR_NAME=google


### PR DESCRIPTION
The failure mode is a little ugly, but will correctly error if there's no file, or any other reason to get an empty string back:

```
rileykarson@rileykarson-mac ~/go/src/github.com/hashicorp/terraform-provider-google
$ make testnolint
go test  -timeout=30s $(pkgs=$(bash scripts/get_unit_test_pkgs.sh); [ -n "$pkgs" ] && echo "$pkgs" || { echo "Error: No test packages found"; exit 1; })
# Error:
malformed import path "Error:": invalid char ':'
FAIL	Error: [setup failed]
# No
package No is not in std (/usr/local/go/src/No)
FAIL	No [setup failed]
# test
package test is not in std (/usr/local/go/src/test)
FAIL	test [setup failed]
# packages
package packages is not in std (/usr/local/go/src/packages)
FAIL	packages [setup failed]
# found
package found is not in std (/usr/local/go/src/found)
FAIL	found [setup failed]
FAIL
make: *** [testnolint] Error 1

rileykarson@rileykarson-mac ~/go/src/github.com/hashicorp/terraform-provider-google
$ vim scripts/get_unit_test_pkgs.sh

rileykarson@rileykarson-mac ~/go/src/github.com/hashicorp/terraform-provider-google
$ make testnolint
go test  -timeout=30s $(pkgs=$(bash scripts/get_unit_test_pkgs.sh); [ -n "$pkgs" ] && echo "$pkgs" || { echo "Error: No test packages found"; exit 1; })
--- FAIL: TestValidateResourceMetadata (0.37s)
    resource_inventory_test.go:236: resource_container_cluster_meta.yaml: Field in provider resource; missing in meta.yaml: google_container_cluster.maintenance_policy.disruption_budget.last_disruption_time
    resource_inventory_test.go:236: resource_container_cluster_meta.yaml: Field in provider resource; missing in meta.yaml: google_container_cluster.maintenance_policy.disruption_budget.last_minor_version_disruption_time
    resource_inventory_test.go:236: resource_sql_provision_script_meta.yaml: Field in provider resource; missing in meta.yaml: google_sql_provision_script.description
    resource_inventory_test.go:244: resource_sql_provision_script_meta.yaml: Field in meta.yaml; missing in provider resource: google_sql_provision_script.name
    resource_inventory_test.go:321: Docs: https://googlecloudplatform.github.io/magic-modules/reference/metadata/
FAIL
FAIL	github.com/hashicorp/terraform-provider-google/google/acctest	1.441s
ok  	github.com/hashicorp/terraform-provider-google/google/functions	2.988s
ok  	github.com/hashicorp/terraform-provider-google/google/fwprovider	4.003s
ok  	github.com/hashicorp/terraform-provider-google/google/fwresource	1.052s
ok  	github.com/hashicorp/terraform-provider-google/google/fwtransport	2.883s
ok  	github.com/hashicorp/terraform-provider-google/google/fwvalidators	2.003s
--- FAIL: TestProvider (0.01s)
    provider_test.go:39: err: resource google_compute_region_network_firewall_policy_association: All fields are ForceNew or Computed w/out Optional, Update is superfluous
FAIL
FAIL	github.com/hashicorp/terraform-provider-google/google/provider	5.064s
ok  	github.com/hashicorp/terraform-provider-google/google/provider/universe	5.464s
ok  	github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager	6.348s
ok  	github.com/hashicorp/terraform-provider-google/google/services/apigee	7.030s
ok  	github.com/hashicorp/terraform-provider-google/google/services/bigquery	8.128s
ok  	github.com/hashicorp/terraform-provider-google/google/services/bigquerydatatransfer	7.276s
ok  	github.com/hashicorp/terraform-provider-google/google/services/bigtable	7.980s
ok  	github.com/hashicorp/terraform-provider-google/google/services/billing	7.655s
ok  	github.com/hashicorp/terraform-provider-google/google/services/binaryauthorization	8.046s
ok  	github.com/hashicorp/terraform-provider-google/google/services/cloudfunctions	8.038s
ok  	github.com/hashicorp/terraform-provider-google/google/services/cloudrun	7.889s
ok  	github.com/hashicorp/terraform-provider-google/google/services/cloudscheduler	8.363s
ok  	github.com/hashicorp/terraform-provider-google/google/services/composer	7.326s
ok  	github.com/hashicorp/terraform-provider-google/google/services/compute	3.295s
ok  	github.com/hashicorp/terraform-provider-google/google/services/container	6.508s
ok  	github.com/hashicorp/terraform-provider-google/google/services/dataflow	4.862s
ok  	github.com/hashicorp/terraform-provider-google/google/services/dataplex	4.113s
ok  	github.com/hashicorp/terraform-provider-google/google/services/dataproc	5.721s
ok  	github.com/hashicorp/terraform-provider-google/google/services/datastream	6.496s
ok  	github.com/hashicorp/terraform-provider-google/google/services/dns	6.860s
ok  	github.com/hashicorp/terraform-provider-google/google/services/filestore	7.672s
ok  	github.com/hashicorp/terraform-provider-google/google/services/firestore	8.308s
ok  	github.com/hashicorp/terraform-provider-google/google/services/iambeta	8.824s
ok  	github.com/hashicorp/terraform-provider-google/google/services/iamworkforcepool	9.254s
ok  	github.com/hashicorp/terraform-provider-google/google/services/kms	7.797s
ok  	github.com/hashicorp/terraform-provider-google/google/services/logging	7.481s
ok  	github.com/hashicorp/terraform-provider-google/google/services/monitoring	8.223s
ok  	github.com/hashicorp/terraform-provider-google/google/services/netapp	8.687s
ok  	github.com/hashicorp/terraform-provider-google/google/services/pubsub	9.449s
ok  	github.com/hashicorp/terraform-provider-google/google/services/redis	8.047s
ok  	github.com/hashicorp/terraform-provider-google/google/services/resourcemanager	6.702s
ok  	github.com/hashicorp/terraform-provider-google/google/services/servicemanagement	7.582s
ok  	github.com/hashicorp/terraform-provider-google/google/services/spanner	8.082s
ok  	github.com/hashicorp/terraform-provider-google/google/services/sql	6.976s
ok  	github.com/hashicorp/terraform-provider-google/google/services/storage	7.929s
ok  	github.com/hashicorp/terraform-provider-google/google/services/vmwareengine	6.958s
ok  	github.com/hashicorp/terraform-provider-google/google/services/workflows	8.972s
ok  	github.com/hashicorp/terraform-provider-google/google/sweeper	0.906s
ok  	github.com/hashicorp/terraform-provider-google/google/tpgdclresource	1.035s
ok  	github.com/hashicorp/terraform-provider-google/google/tpgiamresource	1.713s
ok  	github.com/hashicorp/terraform-provider-google/google/tpgresource	3.551s
ok  	github.com/hashicorp/terraform-provider-google/google/transport	21.448s
ok  	github.com/hashicorp/terraform-provider-google/google/verify	0.187s
FAIL
make: *** [testnolint] Error 1
```