### PR TITLE
fix(compute): prevent google_compute_security_policy rules from being always recreated

### DIFF
--- a/google/services/compute/resource_compute_security_policy.go
+++ b/google/services/compute/resource_compute_security_policy.go
@@ -123,6 +123,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true, // If no rules are set, a default rule is added
+				Set:      resourceComputeSecurityPolicyRuleHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"action": {
@@ -736,6 +737,17 @@ func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams
 		},
 		Description: description,
 	}
+}
+
+// resourceComputeSecurityPolicyRuleHash hashes security policy rules by priority.
+// Rules are uniquely identified by priority, so using priority as the hash
+// allows Terraform to correctly match old and new rules during plan/apply,
+// preventing unnecessary rule recreation when non-priority fields have subtle
+// differences between API response and config (e.g. empty defaults).
+func resourceComputeSecurityPolicyRuleHash(v interface{}) int {
+	raw := v.(map[string]interface{})
+	// Use priority as the hash since it uniquely identifies a rule.
+	return raw["priority"].(int)
 }
 
 func rulesCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {


### PR DESCRIPTION
## Summary

Fixes #16882

Every `terraform apply` on a `google_compute_security_policy` resource shows all rules being destroyed and recreated, even when no rule configuration has changed. This affects 103+ users.

## Root Cause

The `rule` attribute is defined as a `TypeSet`, and Terraform's default `schema.HashResource` computed the set hash over ALL fields in each rule. When the GCP API returned default values for fields the user had not explicitly set (e.g., rate limiting defaults, header action defaults), the hash changed. This hash mismatch made Terraform interpret unchanged rules as "delete old + add new" rather than a no-op or in-place update.

## Fix

Added a custom hash function `resourceComputeSecurityPolicyRuleHash` that computes the set hash based only on the rule's `priority` field — the unique identifier for security policy rules in the GCP API. Added `Set: resourceComputeSecurityPolicyRuleHash` to the `rule` TypeSet schema definition.

This ensures rules are matched by priority regardless of API-added default field values.

## Files Changed

- `google/services/compute/resource_compute_security_policy.go` — Added `resourceComputeSecurityPolicyRuleHash` function and `Set:` attribute on rule TypeSet (~line 123)

## Testing

- Compilation verified clean (`go build`)
- `go vet` passes