### PR TITLE
feat(compute): support self_link input for google_compute_network data source

### DIFF
--- a/google/services/compute/data_source_google_compute_network.go
+++ b/google/services/compute/data_source_google_compute_network.go
@@ -19,6 +19,7 @@ package compute
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -32,7 +33,8 @@ func DataSourceGoogleComputeNetwork() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 
 			"description": {
@@ -69,12 +71,14 @@ func DataSourceGoogleComputeNetwork() *schema.Resource {
 
 			"self_link": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"subnetworks_self_links": {
@@ -93,17 +97,56 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	project, err := tpgresource.GetProject(d, config)
-	if err != nil {
-		return err
+	var project, name string
+
+	if v, ok := d.GetOk("self_link"); ok {
+		// Parse project and name from the self_link.
+		// Network self_links have the form:
+		// https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{name}
+		// or a partial path like projects/{project}/global/networks/{name}
+		selfLink := v.(string)
+		nameFromLink := tpgresource.GetResourceNameFromSelfLink(selfLink)
+		if nameFromLink == "" {
+			return fmt.Errorf("invalid self_link %q: could not extract network name", selfLink)
+		}
+		name = nameFromLink
+
+		// Extract project from self_link
+		parts := strings.Split(selfLink, "/")
+		for i, part := range parts {
+			if part == "projects" && i+1 < len(parts) {
+				project = parts[i+1]
+				break
+			}
+		}
+		if project == "" {
+			// Fall back to provider project
+			project, err = tpgresource.GetProject(d, config)
+			if err != nil {
+				return err
+			}
+		}
+	} else if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		project, err = tpgresource.GetProject(d, config)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("must provide either `self_link` or `name`")
 	}
-	name := d.Get("name").(string)
 
 	id := fmt.Sprintf("projects/%s/global/networks/%s", project, name)
 
 	network, err := config.NewComputeClient(userAgent).Networks.Get(project, name).Do()
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", name), id)
+	}
+	if err := d.Set("name", network.Name); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
 	}
 	if err := d.Set("gateway_ipv4", network.GatewayIPv4); err != nil {
 		return fmt.Errorf("Error setting gateway_ipv4: %s", err)

--- a/google/services/compute/data_source_google_compute_network_internal_test.go
+++ b/google/services/compute/data_source_google_compute_network_internal_test.go
@@ -1,0 +1,58 @@
+package compute
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+)
+
+func TestDataSourceGoogleComputeNetwork_selfLinkParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		selfLink    string
+		wantProject string
+		wantName    string
+	}{
+		{
+			name:        "full self_link",
+			selfLink:    "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-network",
+			wantProject: "my-project",
+			wantName:    "my-network",
+		},
+		{
+			name:        "partial path",
+			selfLink:    "projects/my-project/global/networks/my-network",
+			wantProject: "my-project",
+			wantName:    "my-network",
+		},
+		{
+			name:        "beta API version",
+			selfLink:    "https://www.googleapis.com/compute/beta/projects/test-proj/global/networks/test-net",
+			wantProject: "test-proj",
+			wantName:    "test-net",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName := tpgresource.GetResourceNameFromSelfLink(tc.selfLink)
+			if gotName != tc.wantName {
+				t.Errorf("GetResourceNameFromSelfLink(%q) = %q, want %q", tc.selfLink, gotName, tc.wantName)
+			}
+
+			// Verify project extraction logic matches what's in the data source
+			parts := strings.Split(tc.selfLink, "/")
+			var gotProject string
+			for i, part := range parts {
+				if part == "projects" && i+1 < len(parts) {
+					gotProject = parts[i+1]
+					break
+				}
+			}
+			if gotProject != tc.wantProject {
+				t.Errorf("project from %q = %q, want %q", tc.selfLink, gotProject, tc.wantProject)
+			}
+		})
+	}
+}

--- a/google/services/compute/data_source_google_compute_network_test.go
+++ b/google/services/compute/data_source_google_compute_network_test.go
@@ -100,3 +100,36 @@ data "google_compute_network" "my_network" {
 }
 `, name)
 }
+
+func TestAccDataSourceGoogleNetwork_selfLink(t *testing.T) {
+	t.Parallel()
+
+	networkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleNetworkSelfLinkConfig(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleNetworkCheck("data.google_compute_network.my_network_self_link", "google_compute_network.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleNetworkSelfLinkConfig(name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                     = "%s"
+  description              = "my-description"
+  enable_ula_internal_ipv6 = true
+  auto_create_subnetworks  = false
+}
+
+data "google_compute_network" "my_network_self_link" {
+  self_link = google_compute_network.foobar.self_link
+}
+`, name)
+}


### PR DESCRIPTION
## Summary

Fixes #7863

The `google_compute_network` data source only accepted the `name` attribute to look up a network. Users who had a network's `self_link` (e.g., from a resource output or another data source) had to manually extract the network name. Other similar data sources like `google_compute_subnetwork` already support `self_link` as an input.

## Changes

**Schema:**
- `name`: changed from `Required` to `Optional` + `Computed`
- `self_link`: changed from `Computed` to `Optional` + `Computed`
- `project`: marked as `Computed` (set from the resolved project)

**Read function:**
- When `self_link` is provided, parses it to extract the project (by finding the `projects/` segment) and the network name (last path segment via `GetResourceNameFromSelfLink`)
- Supports full URLs (`https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{name}`) and partial paths (`projects/{project}/global/networks/{name}`)
- When only `name` is provided, falls back to existing behavior using `GetProject` from provider config
- Validates that either `self_link` or `name` must be provided

## Usage

```hcl
# Existing usage (still works)
data "google_compute_network" "by_name" {
  name = "my-network"
}

# New: look up by self_link
data "google_compute_network" "by_self_link" {
  self_link = google_compute_network.main.self_link
}
```

## Files Changed

- `google/services/compute/data_source_google_compute_network.go` — Schema updates + self_link parsing logic
- `google/services/compute/data_source_google_compute_network_internal_test.go` *(new)* — Unit tests for self_link parsing (3 subtests: full URL, partial path, beta API)
- `google/services/compute/data_source_google_compute_network_test.go` — Added acceptance test `TestAccDataSourceGoogleNetwork_selfLink`

## Testing

- All 3 unit tests pass
- Compilation verified clean (`go build`)
- `go vet` passes