### PR TITLE
Fix create_before_destroy duplicate key error in dry run policies

### DIFF
--- a/google/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_egress_policy.go
+++ b/google/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_egress_policy.go
@@ -1217,9 +1217,37 @@ func resourceAccessContextManagerServicePerimeterDryRunEgressPolicyPatchCreateEn
 		return nil, fmt.Errorf("Unable to create ServicePerimeterDryRunEgressPolicy, existing object already found: %+v", found)
 	}
 
-	// Return list with the resource to create appended
+	// With create_before_destroy, an old item with the same title but different
+	// content may still exist. Replace it in-place to avoid a duplicate-title error.
+	expectedTitle, err := expandNestedAccessContextManagerServicePerimeterDryRunEgressPolicyTitle(d.Get("title"), d, meta.(*transport_tpg.Config))
+	if err != nil {
+		return nil, err
+	}
+	expectedFlattenedTitle := flattenNestedAccessContextManagerServicePerimeterDryRunEgressPolicyTitle(expectedTitle, d, meta.(*transport_tpg.Config))
+	titleIdx := -1
+	for idx, itemRaw := range currItems {
+		if itemRaw == nil {
+			continue
+		}
+		item := itemRaw.(map[string]interface{})
+		itemTitle := flattenNestedAccessContextManagerServicePerimeterDryRunEgressPolicyTitle(item["title"], d, meta.(*transport_tpg.Config))
+		if !(tpgresource.IsEmptyValue(reflect.ValueOf(itemTitle)) && tpgresource.IsEmptyValue(reflect.ValueOf(expectedFlattenedTitle))) && reflect.DeepEqual(itemTitle, expectedFlattenedTitle) {
+			titleIdx = idx
+			break
+		}
+	}
+
+	var newItems []interface{}
+	if titleIdx >= 0 {
+		newItems = make([]interface{}, len(currItems))
+		copy(newItems, currItems)
+		newItems[titleIdx] = obj
+	} else {
+		newItems = append(currItems, obj)
+	}
+
 	res := map[string]interface{}{
-		"egressPolicies": append(currItems, obj),
+		"egressPolicies": newItems,
 	}
 	wrapped := map[string]interface{}{
 		"spec": res,

--- a/google/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_ingress_policy.go
+++ b/google/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_ingress_policy.go
@@ -1176,9 +1176,37 @@ func resourceAccessContextManagerServicePerimeterDryRunIngressPolicyPatchCreateE
 		return nil, fmt.Errorf("Unable to create ServicePerimeterDryRunIngressPolicy, existing object already found: %+v", found)
 	}
 
-	// Return list with the resource to create appended
+	// With create_before_destroy, an old item with the same title but different
+	// content may still exist. Replace it in-place to avoid a duplicate-title error.
+	expectedTitle, err := expandNestedAccessContextManagerServicePerimeterDryRunIngressPolicyTitle(d.Get("title"), d, meta.(*transport_tpg.Config))
+	if err != nil {
+		return nil, err
+	}
+	expectedFlattenedTitle := flattenNestedAccessContextManagerServicePerimeterDryRunIngressPolicyTitle(expectedTitle, d, meta.(*transport_tpg.Config))
+	titleIdx := -1
+	for idx, itemRaw := range currItems {
+		if itemRaw == nil {
+			continue
+		}
+		item := itemRaw.(map[string]interface{})
+		itemTitle := flattenNestedAccessContextManagerServicePerimeterDryRunIngressPolicyTitle(item["title"], d, meta.(*transport_tpg.Config))
+		if !(tpgresource.IsEmptyValue(reflect.ValueOf(itemTitle)) && tpgresource.IsEmptyValue(reflect.ValueOf(expectedFlattenedTitle))) && reflect.DeepEqual(itemTitle, expectedFlattenedTitle) {
+			titleIdx = idx
+			break
+		}
+	}
+
+	var newItems []interface{}
+	if titleIdx >= 0 {
+		newItems = make([]interface{}, len(currItems))
+		copy(newItems, currItems)
+		newItems[titleIdx] = obj
+	} else {
+		newItems = append(currItems, obj)
+	}
+
 	res := map[string]interface{}{
-		"ingressPolicies": append(currItems, obj),
+		"ingressPolicies": newItems,
 	}
 	wrapped := map[string]interface{}{
 		"spec": res,


### PR DESCRIPTION
Fixes #26696

When you use create_before_destroy with dry run ingress/egress policies, the old one doesn't get deleted before the new one is created. Since they share the same title, you hit a duplicate key error. Now we check if a policy with that title already exists and replace it instead of appending.