### PR TITLE
`teamcity-nightly-workflow`: update cronjob to use timezone: `America/Los_Angeles'

### DIFF
--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -10,7 +10,8 @@ on:
         dayThreshold:
           default: '3'
     schedule:
-        - cron: '0 2 * * *' # UTC 2AM (-7)-> 7PM PST
+        - cron: '0 19 * * *' # 7PM PST
+          timezone: 'America/Los_Angeles'
 
 jobs:
   rename-TC-nightly-branch:


### PR DESCRIPTION
locks us into 7PM PST, avoiding potentially triggering at 6PM PST on DST causing merge overlaps on branch creation