### PR TITLE
docs: fix grammar error in google_service_account documentation

### DIFF
--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -55,7 +55,7 @@ resource "kubernetes_secret" "google-application-credentials" {
 
 The following arguments are supported:
 
-* `account_id` - (Required) The Google service account ID. This be one of:
+* `account_id` - (Required) The Google service account ID. This be must one of:
 
     * The name of the service account within the project (e.g. `my-service`)
 


### PR DESCRIPTION
## Description
Fixed a small grammar error in the `google_service_account` data source documentation. 
The phrasing "This be one of" was updated to "This must be one of" for clarity and 
consistency with other resource documentation.

## Related Issue
Closes #26532

## References
- Internal Google tracking: b/495459471