### PR TITLE
Fix google_sql_database_instance perpetual diff for connection_pool_config when pooling is disabled

### DIFF
--- a/google/services/sql/resource_sql_database_instance.go
+++ b/google/services/sql/resource_sql_database_instance.go
@@ -2953,7 +2953,10 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		data["database_flags"] = flattenDatabaseFlags(settings.DatabaseFlags)
 	}
 
-	if settings.ConnectionPoolConfig != nil {
+	// Always flatten connection_pool_config when the user has configured it, even
+	// if the API returns nil (which happens when connection_pooling_enabled = false).
+	// This prevents a perpetual diff where Terraform wants to re-add the block.
+	if settings.ConnectionPoolConfig != nil || len(d.Get("settings.0.connection_pool_config").(*schema.Set).List()) > 0 {
 		data["connection_pool_config"] = flattenConnectionPoolConfig(settings.ConnectionPoolConfig)
 	}
 


### PR DESCRIPTION
### Description

Fixes #27133

When `connection_pooling_enabled` is set to `false`, the Cloud SQL API returns `nil` for `ConnectionPoolConfig`. The existing read logic only flattens the config when the API returns non-nil, so the state never contains the block, causing Terraform to perpetually plan re-adding it.

### Fix

Also flatten `connection_pool_config` when the user has explicitly configured the block in their Terraform config (even if the API returns nil), ensuring state matches user expectations.

### Change

```go
// Before
if settings.ConnectionPoolConfig != nil {
    data["connection_pool_config"] = flattenConnectionPoolConfig(settings.ConnectionPoolConfig)
}

// After  
if settings.ConnectionPoolConfig != nil || len(d.Get("settings.0.connection_pool_config").(*schema.Set).List()) > 0 {
    data["connection_pool_config"] = flattenConnectionPoolConfig(settings.ConnectionPoolConfig)
}
```

The `flattenConnectionPoolConfig(nil)` function already correctly returns `[{connection_pooling_enabled: false, flags: []}]`, so this change just ensures the flatten is always called when the user expects the block to exist.

### Testing

- Verified `flattenConnectionPoolConfig(nil)` returns the expected empty/false structure
- The change is minimal and follows the same pattern used elsewhere in this file

### Release Note
```release-note:bug
`google_sql_database_instance`: Fixed perpetual diff when `connection_pool_config` block is configured with `connection_pooling_enabled = false`
```