### PR TITLE
ci: declare least-privilege permissions on the 7 remaining workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -7,6 +7,10 @@ on:
   issue_comment:
     types: [created]
 
+# Removes the waiting-response label via actions/github-script.
+permissions:
+  issues: write
+
 jobs:
   remove_waiting_response:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,11 @@ on:
   issues:
     types: [opened]
 
+# github/issue-labeler reads labeler.yml and applies labels to new issues.
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '50 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -2,6 +2,9 @@ name: "Pull Request Size Labeler"
 
 on: [pull_request]
 
+permissions:
+  pull-requests: write
+
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '10 3 * * *'
 
+# actions/stale labels and closes inactive issues and PRs.
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/upstream-mm.yml
+++ b/.github/workflows/upstream-mm.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
+# Only posts an issue comment on the PR; runs in pull_request_target context.
+permissions:
+  pull-requests: write
+
 jobs:
   pr-warning:
     if: ${{ github.actor != 'modular-magician' }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the seven workflows still inheriting org defaults:

| Workflow | Scope | What needs it |
|----------|-------|---------------|
| `go.yml` | `contents: read` | go build + test |
| `issue-comment-created.yml` | `issues: write` | `actions/github-script` removes the `waiting-response` label |
| `labeler.yml` | `contents: read` + `issues: write` | `github/issue-labeler` reads `.github/labeler.yml` and labels new issues |
| `lock.yml` | `issues: write` + `pull-requests: write` | `dessant/lock-threads@v5` locks 30-day-stale threads and comments |
| `pull-request-size.yml` | `pull-requests: write` | `codelytv/pr-size-labeler` applies size labels |
| `stale.yml` | `issues: write` + `pull-requests: write` | `actions/stale@v9` labels and closes inactive items |
| `upstream-mm.yml` | `pull-requests: write` | `actions/github-script` posts a warning comment on PRs from non-modular-magician users (runs in `pull_request_target`) |

YAML validated locally.