### PR TITLE
ci: update dependencies for GoTest workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.31.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
       with:
         go-version-file: "go.mod"
 


### PR DESCRIPTION
Mirrors updates to go.yml workflow file that were introduced in:
- https://github.com/hashicorp/terraform-provider-google-beta/pull/12312