### PR TITLE
Update IAM documentation for external identity sets

### DIFF
--- a/website/docs/r/storage_managed_folder_iam.html.markdown
+++ b/website/docs/r/storage_managed_folder_iam.html.markdown
@@ -156,6 +156,9 @@ The following arguments are supported:
   * **projectOwner:projectid**: Owners of the given project. For example, "projectOwner:my-example-project"
   * **projectEditor:projectid**: Editors of the given project. For example, "projectEditor:my-example-project"
   * **projectViewer:projectid**: Viewers of the given project. For example, "projectViewer:my-example-project"
+  * **principalSet://iam.googleapis.com/{poolResourceName}/attribute.{key}/{value}**: An external identity set from a Workload Identity Pool, optionally constrained by an attribute (e.g. GitHub Actions branch via attribute.repository). Example: "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/github-pool/attribute.repository/your-org/your-repo"
+
+
 
 * `role` - (Required) The role that should be applied. Only one
     `google_storage_managed_folder_iam_binding` can be used per role. Note that custom roles must be of the format


### PR DESCRIPTION
Added documentation for `principalSet://` members representing external identity sets from IAM Workload Identity Pools, including an example using attribute-based selection (e.g. GitHub Actions attribute.ref). 
Verified this format is accepted by the underlying IAM API and works via gcloud and the Cloud Console UI.

For Ex
```
# Create the managed folder (run once)
gcloud storage managed-folders create gs://YOUR_BUCKET/nx-cache/

# Add IAM binding on the managed folder
gcloud storage managed-folders add-iam-policy-binding \
  gs://YOUR_BUCKET/nx-cache/ \
  --role="roles/storage.objectCreator" \
  --member="principalSet://iam.googleapis.com/YOUR_POOL_FULL_NAME/attribute.ref/refs/heads/main"

# Verify the IAM policy on the managed folder
gcloud storage managed-folders get-iam-policy gs://YOUR_BUCKET/nx-cache/
```