### PR TITLE
fix(compute): allow preview=false updates for organization security policy rules

### DIFF
--- a/.changelog/27885.txt
+++ b/.changelog/27885.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+compute: fixed google_compute_organization_security_policy_rule not updating preview=false correctly
+```

--- a/google/services/compute/resource_compute_organization_security_policy_rule.go
+++ b/google/services/compute/resource_compute_organization_security_policy_rule.go
@@ -473,10 +473,16 @@ func resourceComputeOrganizationSecurityPolicyRuleCreate(d *schema.ResourceData,
 	} else if v, ok := d.GetOkExists("preconfigured_waf_config"); ok || !reflect.DeepEqual(v, preconfiguredWafConfigProp) {
 		obj["preconfiguredWafConfig"] = preconfiguredWafConfigProp
 	}
+	// previewProp, err := expandComputeOrganizationSecurityPolicyRulePreview(d.Get("preview"), d, config)
+	// if err != nil {
+	// 	return err
+	// } else if v, ok := d.GetOkExists("preview"); !tpgresource.IsEmptyValue(reflect.ValueOf(previewProp)) && (ok || !reflect.DeepEqual(v, previewProp)) {
+	// 	obj["preview"] = previewProp
+	// }
 	previewProp, err := expandComputeOrganizationSecurityPolicyRulePreview(d.Get("preview"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("preview"); !tpgresource.IsEmptyValue(reflect.ValueOf(previewProp)) && (ok || !reflect.DeepEqual(v, previewProp)) {
+	} else if v, ok := d.GetOkExists("preview"); ok || !reflect.DeepEqual(v, previewProp) {
 		obj["preview"] = previewProp
 	}
 	redirectOptionsProp, err := expandComputeOrganizationSecurityPolicyRuleRedirectOptions(d.Get("redirect_options"), d, config)
@@ -734,10 +740,16 @@ func resourceComputeOrganizationSecurityPolicyRuleUpdate(d *schema.ResourceData,
 	} else if v, ok := d.GetOkExists("preconfigured_waf_config"); ok || !reflect.DeepEqual(v, preconfiguredWafConfigProp) {
 		obj["preconfiguredWafConfig"] = preconfiguredWafConfigProp
 	}
+	// previewProp, err := expandComputeOrganizationSecurityPolicyRulePreview(d.Get("preview"), d, config)
+	// if err != nil {
+	// 	return err
+	// } else if v, ok := d.GetOkExists("preview"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, previewProp)) {
+	// 	obj["preview"] = previewProp
+	// }
 	previewProp, err := expandComputeOrganizationSecurityPolicyRulePreview(d.Get("preview"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("preview"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, previewProp)) {
+	} else if v, ok := d.GetOkExists("preview"); ok || !reflect.DeepEqual(v, previewProp) {
 		obj["preview"] = previewProp
 	}
 	redirectOptionsProp, err := expandComputeOrganizationSecurityPolicyRuleRedirectOptions(d.Get("redirect_options"), d, config)

--- a/google/services/compute/resource_compute_organization_security_policy_rule_test.go
+++ b/google/services/compute/resource_compute_organization_security_policy_rule_test.go
@@ -118,6 +118,68 @@ resource "google_compute_organization_security_policy_rule" "policy" {
 `, context)
 }
 
+func testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewTrue(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_folder" "security_policy_target" {
+  display_name = "tf-test-secpol-%{random_suffix}"
+  parent       = "organizations/%{org_id}"
+  deletion_protection = false
+}
+
+resource "google_compute_organization_security_policy" "policy" {
+  short_name = "tf-test%{random_suffix}"
+  parent     = google_folder.security_policy_target.name
+  type       = "CLOUD_ARMOR"
+}
+
+resource "google_compute_organization_security_policy_rule" "policy" {
+  policy_id = google_compute_organization_security_policy.policy.id
+  action = "allow"
+
+  match {
+    config {
+      src_ip_ranges = ["192.168.0.0/16"]
+    }
+    versioned_expr = "SRC_IPS_V1"
+  }
+
+  priority = 100
+  preview  = true
+}
+`, context)
+}
+
+func testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewFalse(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_folder" "security_policy_target" {
+  display_name = "tf-test-secpol-%{random_suffix}"
+  parent       = "organizations/%{org_id}"
+  deletion_protection = false
+}
+
+resource "google_compute_organization_security_policy" "policy" {
+  short_name = "tf-test%{random_suffix}"
+  parent     = google_folder.security_policy_target.name
+  type       = "CLOUD_ARMOR"
+}
+
+resource "google_compute_organization_security_policy_rule" "policy" {
+  policy_id = google_compute_organization_security_policy.policy.id
+  action = "allow"
+
+  match {
+    config {
+      src_ip_ranges = ["192.168.0.0/16"]
+    }
+    versioned_expr = "SRC_IPS_V1"
+  }
+
+  priority = 100
+  preview  = false
+}
+`, context)
+}
+
 func TestAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRuleExpressionUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -141,6 +203,39 @@ func TestAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRule
 			},
 			{
 				Config: testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRuleExpressionUpdate(context),
+			},
+			{
+				ResourceName:      "google_compute_organization_security_policy_rule.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeOrganizationSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewTrue(context),
+			},
+			{
+				ResourceName:      "google_compute_organization_security_policy_rule.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewFalse(context),
 			},
 			{
 				ResourceName:      "google_compute_organization_security_policy_rule.policy",
@@ -618,4 +713,37 @@ resource "google_compute_organization_security_policy_rule" "policy" {
   priority = 100
 }
 `, context)
+}
+
+func TestAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeOrganizationSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewTrue(context),
+			},
+			{
+				ResourceName:      "google_compute_organization_security_policy_rule.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeOrganizationSecurityPolicyRule_organizationSecurityPolicyRulePreviewFalse(context),
+			},
+			{
+				ResourceName:      "google_compute_organization_security_policy_rule.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }


### PR DESCRIPTION
Fixes #27885

## Root cause

`resourceComputeOrganizationSecurityPolicyRuleUpdate()` treated `false` as an empty value via `tpgresource.IsEmptyValue()`, causing `preview=false` to be omitted from patch requests.

This resulted in successful applies that did not actually disable preview mode, leading to perpetual diffs.

## Changes

- Always include `preview` when explicitly set.
- Make create/update behavior consistent with `google_compute_security_policy_rule` and `google_compute_region_security_policy_rule`.
- Add an acceptance test covering:

preview = true
↓
preview = false