### PR TITLE
Fix App Hub extendedMetadata panic and type validation crash (fixes #26476)

### DIFF
--- a/google/services/apphub/resource_apphub_service.go
+++ b/google/services/apphub/resource_apphub_service.go
@@ -975,20 +975,31 @@ func flattenApphubServiceServicePropertiesExtendedMetadata(v interface{}, d *sch
 	if v == nil {
 		return v
 	}
-	l := v.([]interface{})
-	transformed := make([]interface{}, 0, len(l))
-	for _, raw := range l {
-		original := raw.(map[string]interface{})
-		if len(original) < 1 {
-			// Do not include empty json objects coming back from the api
-			continue
+	if m, ok := v.(map[string]interface{}); ok {
+		transformed := make([]interface{}, 0, len(m))
+		for key, val := range m {
+			transformed = append(transformed, map[string]interface{}{
+				"key":   flattenApphubServiceServicePropertiesExtendedMetadataKey(key, d, config),
+				"value": flattenApphubServiceServicePropertiesExtendedMetadataValue(val, d, config),
+			})
 		}
-		transformed = append(transformed, map[string]interface{}{
-			"key":   flattenApphubServiceServicePropertiesExtendedMetadataKey(original["key"], d, config),
-			"value": flattenApphubServiceServicePropertiesExtendedMetadataValue(original["value"], d, config),
-		})
+		return transformed
 	}
-	return transformed
+	if l, ok := v.([]interface{}); ok {
+		transformed := make([]interface{}, 0, len(l))
+		for _, raw := range l {
+			original, ok := raw.(map[string]interface{})
+			if !ok || len(original) < 1 {
+				continue
+			}
+			transformed = append(transformed, map[string]interface{}{
+				"key":   flattenApphubServiceServicePropertiesExtendedMetadataKey(original["key"], d, config),
+				"value": flattenApphubServiceServicePropertiesExtendedMetadataValue(original["value"], d, config),
+			})
+		}
+		return transformed
+	}
+	return nil
 }
 func flattenApphubServiceServicePropertiesExtendedMetadataKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
@@ -1010,7 +1021,17 @@ func flattenApphubServiceServicePropertiesExtendedMetadataValue(v interface{}, d
 	return []interface{}{transformed}
 }
 func flattenApphubServiceServicePropertiesExtendedMetadataValueMetadataStruct(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	return v
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func flattenApphubServiceServicePropertiesExtendedMetadataValueExtendedMetadataSchema(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {

--- a/google/services/apphub/resource_apphub_workload.go
+++ b/google/services/apphub/resource_apphub_workload.go
@@ -939,20 +939,31 @@ func flattenApphubWorkloadWorkloadPropertiesExtendedMetadata(v interface{}, d *s
 	if v == nil {
 		return v
 	}
-	l := v.([]interface{})
-	transformed := make([]interface{}, 0, len(l))
-	for _, raw := range l {
-		original := raw.(map[string]interface{})
-		if len(original) < 1 {
-			// Do not include empty json objects coming back from the api
-			continue
+	if m, ok := v.(map[string]interface{}); ok {
+		transformed := make([]interface{}, 0, len(m))
+		for key, val := range m {
+			transformed = append(transformed, map[string]interface{}{
+				"key":   flattenApphubWorkloadWorkloadPropertiesExtendedMetadataKey(key, d, config),
+				"value": flattenApphubWorkloadWorkloadPropertiesExtendedMetadataValue(val, d, config),
+			})
 		}
-		transformed = append(transformed, map[string]interface{}{
-			"key":   flattenApphubWorkloadWorkloadPropertiesExtendedMetadataKey(original["key"], d, config),
-			"value": flattenApphubWorkloadWorkloadPropertiesExtendedMetadataValue(original["value"], d, config),
-		})
+		return transformed
 	}
-	return transformed
+	if l, ok := v.([]interface{}); ok {
+		transformed := make([]interface{}, 0, len(l))
+		for _, raw := range l {
+			original, ok := raw.(map[string]interface{})
+			if !ok || len(original) < 1 {
+				continue
+			}
+			transformed = append(transformed, map[string]interface{}{
+				"key":   flattenApphubWorkloadWorkloadPropertiesExtendedMetadataKey(original["key"], d, config),
+				"value": flattenApphubWorkloadWorkloadPropertiesExtendedMetadataValue(original["value"], d, config),
+			})
+		}
+		return transformed
+	}
+	return nil
 }
 func flattenApphubWorkloadWorkloadPropertiesExtendedMetadataKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
@@ -974,7 +985,17 @@ func flattenApphubWorkloadWorkloadPropertiesExtendedMetadataValue(v interface{},
 	return []interface{}{transformed}
 }
 func flattenApphubWorkloadWorkloadPropertiesExtendedMetadataValueMetadataStruct(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	return v
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func flattenApphubWorkloadWorkloadPropertiesExtendedMetadataValueExtendedMetadataSchema(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {


### PR DESCRIPTION
This Pull Request resolves the runtime panic and subsequent schema validation type mismatch errors encountered when deploying or importing `google_apphub_service` and `google_apphub_workload` resources that have `extendedMetadata` populated (such as GKE services registered in the Agent Registry as `MCP_SERVER` types).

This fixes the issues tracked in **#26476**.

### 🔍 Root Cause Analysis

1. **The Panic Bug**: The auto-generated provider code in `flattenApphubServiceServicePropertiesExtendedMetadata` and `flattenApphubWorkloadWorkloadPropertiesExtendedMetadata` expects the API response's `extendedMetadata` field to be a slice (`[]interface{}`). However, the Google Cloud API returns it as a JSON map (`map[string]interface{}`) where keys are schemas (e.g. `"apphub.googleapis.com/McpServer"`). This type mismatch leads to a hard type assertion panic (`panic: interface conversion: interface {} is map[string]interface {}, not []interface {}`) that crashes the provider during state reads.
2. **The Schema Type Mismatch**: The schema defines `metadata_struct` as a `schema.TypeString` (representing a JSON-serialized string), but the API returns a JSON object (a map). The generated code returned this map directly (`return v`), which caused a schema validation type mismatch error: `expected type 'string', got unconvertible type 'map[string]interface {}'`.

### 🛠️ Changes Implemented

* **Robust Type Handling**: Updated the `extendedMetadata` flattening functions in both `resource_apphub_service.go` and `resource_apphub_workload.go` to handle both map and slice structures. For maps, it correctly iterates over keys and values and transforms them into the list of key-value blocks expected by the Terraform schema.
* **Auto-Serialization**: Updated the `metadata_struct` flattening functions to automatically serialize the incoming metadata map into a valid JSON string, satisfying the schema's `TypeString` requirement.

### 🧪 Verification & Testing
Tested end-to-end in a live GCP environment using `terraform import` and `terraform apply` on GKE-based MCP servers:
* Bypasses the crash entirely.
* Successfully imports and refreshes the state of App Hub services with full metadata.
* Repeated applications run cleanly without any type validation errors.
