### PR TITLE
fix:  panic in  when creating  resources programmatically via the SDK…

### DIFF
--- a/.changelog/28194.txt
+++ b/.changelog/28194.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+container: fixed a panic in `expandNodeConfig` when creating `google_container_cluster` resources programmatically via the SDK without a raw `node_config` HCL block (impacts Crossplane's upjet-based provider, Config Connector, and similar callers)
+```

--- a/google/services/container/node_config.go
+++ b/google/services/container/node_config.go
@@ -1827,6 +1827,14 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 		rawConfigNPRoot := d.GetRawConfig()
 		// if we have a prefix, we're in `node_pool.N.` in GKE Cluster. Traverse the RawConfig object to reach that
 		// root, at which point local references work going forwards.
+		//
+		// Guard: some callers (programmatic SDK bridges such as Crossplane's
+		// upjet-generated provider, Config Connector, etc.) do not populate the
+		// `node_pool` attribute in raw config even though `prefix` is set. In
+		// that case GetAttr("node_pool") returns cty.NullVal and Index(N)
+		// panics with "value is null". Skip the raw-config sub-fixes below
+		// cleanly in that case. See hashicorp/terraform-provider-google#28190.
+		skipRawConfigSubFixes := false
 		if prefix != "" {
 			parts := strings.Split(prefix, ".") // "node_pool.N." -> ["node_pool" "N", ""]
 			npIndex, err := strconv.Atoi(parts[1])
@@ -1834,35 +1842,42 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 				panic(fmt.Errorf("unexpected format for node pool path prefix: %w. value: %v", err, prefix))
 			}
 
-			rawConfigNPRoot = rawConfigNPRoot.GetAttr("node_pool").Index(cty.NumberIntVal(int64(npIndex)))
-		}
-
-		if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-			if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-				v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota")
-				if v == cty.NullVal(cty.Bool) {
-					nc.KubeletConfig.CpuCfsQuota = true
-				} else if v.False() { // force-send explicit false to API
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
-				}
+			npAttr := rawConfigNPRoot.GetAttr("node_pool")
+			if npAttr.IsNull() || !npAttr.CanIterateElements() || npAttr.LengthInt() <= npIndex {
+				skipRawConfigSubFixes = true
+			} else {
+				rawConfigNPRoot = npAttr.Index(cty.NumberIntVal(int64(npIndex)))
 			}
 		}
-		// end cpu_cfs_quota fix
 
-		// start shutdown_grace_period ForceSendFields fix
-		if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-			if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-				vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
-				if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
-				}
-				vSGPC := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_critical_pods_seconds")
-				if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+		if !skipRawConfigSubFixes {
+			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
+				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
+					v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota")
+					if v == cty.NullVal(cty.Bool) {
+						nc.KubeletConfig.CpuCfsQuota = true
+					} else if v.False() { // force-send explicit false to API
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
+					}
 				}
 			}
+			// end cpu_cfs_quota fix
+
+			// start shutdown_grace_period ForceSendFields fix
+			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
+				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
+					vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
+					if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
+					}
+					vSGPC := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_critical_pods_seconds")
+					if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+					}
+				}
+			}
+			// end shutdown_grace_period ForceSendFields fix
 		}
-		// end shutdown_grace_period ForceSendFields fix
 	}
 
 	if v, ok := nodeConfig["linux_node_config"]; ok {

--- a/google/services/container/resource_container_cluster_test.go
+++ b/google/services/container/resource_container_cluster_test.go
@@ -7440,6 +7440,38 @@ func TestAccContainerCluster_withCpuCfsQuotaPool(t *testing.T) {
 	})
 }
 
+// TestAccContainerCluster_withoutNodeConfigBlock is a regression test for
+// hashicorp/terraform-provider-google#28190. It creates a cluster with
+// remove_default_node_pool=true and no `node_config { ... }` block, which
+// previously caused a "value is null" panic in expandNodeConfig when the
+// cpu_cfs_quota raw-config traversal dereferenced an absent node_pool
+// attribute.
+func TestAccContainerCluster_withoutNodeConfigBlock(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	npName := fmt.Sprintf("tf-test-cluster-nodepool-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withoutNodeConfigBlock(clusterName, npName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:            "google_container_cluster.no_node_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_network_tier_config(t *testing.T) {
 	t.Parallel()
 
@@ -7631,6 +7663,30 @@ resource "google_container_cluster" "primary" {
   }
 }
 `, projectID, name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withoutNodeConfigBlock(clusterName, npName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "no_node_config" {
+  name                     = "%s"
+  location                 = "us-central1-a"
+  initial_node_count       = 1
+  remove_default_node_pool = true
+  network                  = "%s"
+  subnetwork               = "%s"
+
+  deletion_protection = false
+  # NOTE: intentionally no `+"`node_config { ... }`"+` block on the cluster.
+  # See hashicorp/terraform-provider-google#28190.
+}
+
+resource "google_container_node_pool" "workload" {
+  name       = "%s"
+  location   = "us-central1-a"
+  cluster    = google_container_cluster.no_node_config.name
+  node_count = 1
+}
+`, clusterName, networkName, subnetworkName, npName)
 }
 
 func testAccContainerCluster_networkingModeRoutes(firstName, secondName, networkName, subnetworkName string) string {


### PR DESCRIPTION
Fixes #28190

### Summary

`expandNodeConfig` traverses `d.GetRawConfig()` to determine whether the caller explicitly set `node_config.kubelet_config.cpu_cfs_quota` and `shutdown_grace_period_seconds` / `shutdown_grace_period_critical_pods_seconds`

When called on a `google_container_node_pool` block that belongs to a `google_container_cluster` (prefix `node_pool.N`), the traversal indexes into node_pool without first checking that node_pool exists in raw config

Programmatic SDK callers (Crossplane's upjet-based provider, Config Connector, terraform-plugin-mux consumers, etc.) do not populate the node_pool attribute in raw config, so `GetAttr("node_pool").Index(N)` panics with value is null on every create attempt of any google_container_cluster that uses inline node pools without a raw HCL node_pool block

### Root Cause

Introduced in commit d9313fa07 (PR #15268), which fixed the semantic issue in #15767. The fix added raw-config reads for cpu_cfs_quota but did not guard against the case where the parent node_pool list is absent in raw config. A second, similarly-unguarded block was later added for shutdown_grace_period_seconds in PR #17999 (28015), inheriting the same latent bug

## Reproduction, stack trace, and impact analysis: #28190

### Fix

Guard the raw-config traversal: if `node_pool is null,` unindexable, or shorter than npIndex, skip both raw-config sub-fixes cleanly. The API-default behaviour then applies (`cpu_cfs_quota=true`, `shutdown_grace_period` unset), matching v6.x behaviour when the block was absent.

```go
npAttr := rawConfigNPRoot.GetAttr("node_pool")
if npAttr.IsNull() || !npAttr.CanIterateElements() || npAttr.LengthInt() <= npIndex {
    skipRawConfigSubFixes = true
} else {
    rawConfigNPRoot = npAttr.Index(cty.NumberIntVal(int64(npIndex)))
}

if !skipRawConfigSubFixes {
    // ... existing cpu_cfs_quota + shutdown_grace_period_seconds blocks
}
```

### Tests

- New acceptance test: TestAccContainerCluster_withoutNodeConfigBlock — regression guard. Creates a google_container_cluster with remove_default_node_pool = true and no node_config block, then attaches a google_container_node_pool resource. Before the fix, this panics on create. After the fix, it succeeds.

### Release Note

container: fixed a panic in expandNodeConfig when creating google_container_cluster resources programmatically via the SDK without a raw node_config HCL block (impacts Crossplane's upjet-based provider, Config Connector, and similar callers)

### Risk Assessment

Low. The change is narrow (one new guard clause) and preserves all existing HCL behavior. Only affects the previously-panicking programmatic path.