### PR TITLE
feat(modelarmor): add filter_version_selector support

### DIFF
--- a/google/services/modelarmor/resource_model_armor_template.go
+++ b/google/services/modelarmor/resource_model_armor_template.go
@@ -359,6 +359,22 @@ end user if the prompt trips Model Armor filters.`,
 INSPECT_ONLY
 INSPECT_AND_BLOCK`,
 						},
+						"filter_version_selector": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `Selects the filter version to use for this template.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"version": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Description: `The filter version. Accepts 'LATEST' (newest version),
+'STABLE' (current stable version), or a specific version such as 'v1'.`,
+									},
+								},
+							},
+						},
 						"ignore_partial_invocation_failures": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -1029,6 +1045,21 @@ func flattenModelArmorTemplateTemplateMetadata(v interface{}, d *schema.Resource
 	transformed["custom_llm_response_safety_error_code"] = original["customLlmResponseSafetyErrorCode"]
 	transformed["custom_llm_response_safety_error_message"] = original["customLlmResponseSafetyErrorMessage"]
 	transformed["enforcement_type"] = original["enforcementType"]
+	transformed["filter_version_selector"] =
+		flattenModelArmorTemplateTemplateMetadataFilterVersionSelector(original["filterVersionSelector"], d, config)
+	return []interface{}{transformed}
+}
+
+func flattenModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["version"] = original["version"]
 	return []interface{}{transformed}
 }
 
@@ -1413,6 +1444,13 @@ func expandModelArmorTemplateTemplateMetadata(v interface{}, d tpgresource.Terra
 		transformed["enforcementType"] = transformedEnforcementType
 	}
 
+	transformedFilterVersionSelector, err := expandModelArmorTemplateTemplateMetadataFilterVersionSelector(original["filter_version_selector"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedFilterVersionSelector); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["filterVersionSelector"] = transformedFilterVersionSelector
+	}
+
 	return transformed, nil
 }
 
@@ -1471,6 +1509,32 @@ func expandModelArmorTemplateTemplateMetadataCustomLlmResponseSafetyErrorMessage
 }
 
 func expandModelArmorTemplateTemplateMetadataEnforcementType(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedVersion, err := expandModelArmorTemplateTemplateMetadataFilterVersionSelectorVersion(original["version"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedVersion); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["version"] = transformedVersion
+	}
+
+	return transformed, nil
+}
+
+func expandModelArmorTemplateTemplateMetadataFilterVersionSelectorVersion(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google/services/modelarmor/resource_model_armor_template_generated_meta.yaml
+++ b/google/services/modelarmor/resource_model_armor_template_generated_meta.yaml
@@ -31,6 +31,7 @@ fields:
     - api_field: templateMetadata.customPromptSafetyErrorCode
     - api_field: templateMetadata.customPromptSafetyErrorMessage
     - api_field: templateMetadata.enforcementType
+    - api_field: templateMetadata.filterVersionSelector.version
     - api_field: templateMetadata.ignorePartialInvocationFailures
     - api_field: templateMetadata.logSanitizeOperations
     - api_field: templateMetadata.logTemplateOperations

--- a/google/services/modelarmor/resource_model_armor_template_test.go
+++ b/google/services/modelarmor/resource_model_armor_template_test.go
@@ -151,6 +151,9 @@ func testAccModelArmorTemplate_initial(context map[string]interface{}) string {
           custom_prompt_safety_error_message       = "This is a custom error message for prompt"
           custom_llm_response_safety_error_code    = 401
           enforcement_type                         = "INSPECT_ONLY"
+          filter_version_selector {
+            version = "LATEST"
+          }
         }
       }
     `, context)

--- a/website/docs/r/model_armor_template.html.markdown
+++ b/website/docs/r/model_armor_template.html.markdown
@@ -371,12 +371,24 @@ The following arguments are supported:
   INSPECT_ONLY
   INSPECT_AND_BLOCK
 
+* `filter_version_selector` -
+  (Optional)
+  Selects the filter version to use for this template.
+  Structure is [documented below](#nested_template_metadata_filter_version_selector).
+
 
 <a name="nested_template_metadata_multi_language_detection"></a>The `multi_language_detection` block supports:
 
 * `enable_multi_language_detection` -
   (Required)
   If true, multi language detection will be enabled.
+
+<a name="nested_template_metadata_filter_version_selector"></a>The `filter_version_selector` block supports:
+
+* `version` -
+  (Optional)
+  The filter version. Accepts `LATEST` (newest version),
+  `STABLE` (current stable version), or a specific version such as `v1`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Define filter_version_selector schema with optional version field
- Include filter_version_selector in flattenModelArmorTemplateTemplateMetadata
- Implement expandModelArmorTemplateTemplateMetadataFilterVersionSelector and version helper
- Update generated metadata yaml to map filterVersionSelector.version
- Extend acceptance test to set filter_version_selector version "LATEST"
- Document filter_version_selector argument and nested block in resource docs