### PR TITLE
feat(model armor): add filter version selection to google_model_armor_template

### DIFF
--- a/google/services/modelarmor/resource_model_armor_template.go
+++ b/google/services/modelarmor/resource_model_armor_template.go
@@ -362,15 +362,31 @@ INSPECT_AND_BLOCK`,
 						"filter_version_selector": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Description: `Selects the filter version to use for this template.`,
+							Description: `Selects the filter version to use for this template. Set exactly one of 'alias' or 'version'.`,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"alias": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Description: `A predefined filter version alias. The template automatically follows the
+version this alias points to. Possible values:
+FILTER_VERSION_ALIAS_STABLE
+FILTER_VERSION_ALIAS_LATEST`,
+										ExactlyOneOf: []string{
+											"template_metadata.0.filter_version_selector.0.alias",
+											"template_metadata.0.filter_version_selector.0.version",
+										},
+									},
 									"version": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Description: `The filter version. Accepts 'LATEST' (newest version),
-'STABLE' (current stable version), or a specific version such as 'v1'.`,
+										Description: `Pins the template to a specific, immutable filter version. Expected
+format is a case-sensitive string such as 'v1' or 'v2'.`,
+										ExactlyOneOf: []string{
+											"template_metadata.0.filter_version_selector.0.alias",
+											"template_metadata.0.filter_version_selector.0.version",
+										},
 									},
 								},
 							},
@@ -1059,6 +1075,7 @@ func flattenModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{
 		return nil
 	}
 	transformed := make(map[string]interface{})
+	transformed["alias"] = original["alias"]
 	transformed["version"] = original["version"]
 	return []interface{}{transformed}
 }
@@ -1524,6 +1541,13 @@ func expandModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{}
 	original := raw.(map[string]interface{})
 	transformed := make(map[string]interface{})
 
+	transformedAlias, err := expandModelArmorTemplateTemplateMetadataFilterVersionSelectorAlias(original["alias"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedAlias); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["alias"] = transformedAlias
+	}
+
 	transformedVersion, err := expandModelArmorTemplateTemplateMetadataFilterVersionSelectorVersion(original["version"], d, config)
 	if err != nil {
 		return nil, err
@@ -1532,6 +1556,10 @@ func expandModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{}
 	}
 
 	return transformed, nil
+}
+
+func expandModelArmorTemplateTemplateMetadataFilterVersionSelectorAlias(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
 }
 
 func expandModelArmorTemplateTemplateMetadataFilterVersionSelectorVersion(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {

--- a/google/services/modelarmor/resource_model_armor_template.go
+++ b/google/services/modelarmor/resource_model_armor_template.go
@@ -369,16 +369,14 @@ INSPECT_AND_BLOCK`,
 									"alias": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Description: `A predefined filter version alias. The template automatically follows the
-version this alias points to. Set only one of 'alias' or 'version'. Possible values:
+										Description: `A predefined filter version alias. Possible values:
 FILTER_VERSION_ALIAS_STABLE
 FILTER_VERSION_ALIAS_LATEST`,
 									},
 									"version": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Description: `Pins the template to a specific, immutable filter version. Expected
-format is a case-sensitive string such as 'v1' or 'v2'. Set only one of 'alias' or 'version'.`,
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `Pins the template to a specific, immutable filter version, e.g. 'v1'.`,
 									},
 								},
 							},

--- a/google/services/modelarmor/resource_model_armor_template.go
+++ b/google/services/modelarmor/resource_model_armor_template.go
@@ -370,23 +370,15 @@ INSPECT_AND_BLOCK`,
 										Type:     schema.TypeString,
 										Optional: true,
 										Description: `A predefined filter version alias. The template automatically follows the
-version this alias points to. Possible values:
+version this alias points to. Set only one of 'alias' or 'version'. Possible values:
 FILTER_VERSION_ALIAS_STABLE
 FILTER_VERSION_ALIAS_LATEST`,
-										ExactlyOneOf: []string{
-											"template_metadata.0.filter_version_selector.0.alias",
-											"template_metadata.0.filter_version_selector.0.version",
-										},
 									},
 									"version": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Description: `Pins the template to a specific, immutable filter version. Expected
-format is a case-sensitive string such as 'v1' or 'v2'.`,
-										ExactlyOneOf: []string{
-											"template_metadata.0.filter_version_selector.0.alias",
-											"template_metadata.0.filter_version_selector.0.version",
-										},
+format is a case-sensitive string such as 'v1' or 'v2'. Set only one of 'alias' or 'version'.`,
 									},
 								},
 							},

--- a/google/services/modelarmor/resource_model_armor_template.go
+++ b/google/services/modelarmor/resource_model_armor_template.go
@@ -359,6 +359,22 @@ end user if the prompt trips Model Armor filters.`,
 INSPECT_ONLY
 INSPECT_AND_BLOCK`,
 						},
+						"filter_version_selector": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `Selects the filter version to use for this template.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"version": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Description: `The filter version. Accepts 'LATEST' (newest version),
+'STABLE' (current stable version), or a specific version such as 'v1'.`,
+									},
+								},
+							},
+						},
 						"ignore_partial_invocation_failures": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -1029,6 +1045,21 @@ func flattenModelArmorTemplateTemplateMetadata(v interface{}, d *schema.Resource
 	transformed["custom_llm_response_safety_error_code"] = original["customLlmResponseSafetyErrorCode"]
 	transformed["custom_llm_response_safety_error_message"] = original["customLlmResponseSafetyErrorMessage"]
 	transformed["enforcement_type"] = original["enforcementType"]
+	transformed["filter_version_selector"] =
+		flattenModelArmorTemplateTemplateMetadataFilterVersionSelector(original["filterVersionSelector"], d, config)
+	return []interface{}{transformed}
+}
+
+func flattenModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["version"] = original["version"]
 	return []interface{}{transformed}
 }
 
@@ -1413,6 +1444,13 @@ func expandModelArmorTemplateTemplateMetadata(v interface{}, d tpgresource.Terra
 		transformed["enforcementType"] = transformedEnforcementType
 	}
 
+	transformedFilterVersionSelector, err := expandModelArmorTemplateTemplateMetadataFilterVersionSelector(original["filter_version_selector"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedFilterVersionSelector); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["filterVersionSelector"] = transformedFilterVersionSelector
+	}
+
 	return transformed, nil
 }
 
@@ -1471,6 +1509,32 @@ func expandModelArmorTemplateTemplateMetadataCustomLlmResponseSafetyErrorMessage
 }
 
 func expandModelArmorTemplateTemplateMetadataEnforcementType(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandModelArmorTemplateTemplateMetadataFilterVersionSelector(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedVersion, err := expandModelArmorTemplateTemplateMetadataFilterVersionSelectorVersion(original["version"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedVersion); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["version"] = transformedVersion
+	}
+
+	return transformed, nil
+}
+
+func expandModelArmorTemplateTemplateMetadataFilterVersionSelectorVersion(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google/services/modelarmor/resource_model_armor_template_generated_meta.yaml
+++ b/google/services/modelarmor/resource_model_armor_template_generated_meta.yaml
@@ -31,6 +31,7 @@ fields:
     - api_field: templateMetadata.customPromptSafetyErrorCode
     - api_field: templateMetadata.customPromptSafetyErrorMessage
     - api_field: templateMetadata.enforcementType
+    - api_field: templateMetadata.filterVersionSelector.version
     - api_field: templateMetadata.ignorePartialInvocationFailures
     - api_field: templateMetadata.logSanitizeOperations
     - api_field: templateMetadata.logTemplateOperations

--- a/google/services/modelarmor/resource_model_armor_template_generated_meta.yaml
+++ b/google/services/modelarmor/resource_model_armor_template_generated_meta.yaml
@@ -31,6 +31,7 @@ fields:
     - api_field: templateMetadata.customPromptSafetyErrorCode
     - api_field: templateMetadata.customPromptSafetyErrorMessage
     - api_field: templateMetadata.enforcementType
+    - api_field: templateMetadata.filterVersionSelector.alias
     - api_field: templateMetadata.filterVersionSelector.version
     - api_field: templateMetadata.ignorePartialInvocationFailures
     - api_field: templateMetadata.logSanitizeOperations

--- a/google/services/modelarmor/resource_model_armor_template_test.go
+++ b/google/services/modelarmor/resource_model_armor_template_test.go
@@ -152,7 +152,7 @@ func testAccModelArmorTemplate_initial(context map[string]interface{}) string {
           custom_llm_response_safety_error_code    = 401
           enforcement_type                         = "INSPECT_ONLY"
           filter_version_selector {
-            version = "LATEST"
+            alias = "FILTER_VERSION_ALIAS_LATEST"
           }
         }
       }

--- a/google/services/modelarmor/resource_model_armor_template_test.go
+++ b/google/services/modelarmor/resource_model_armor_template_test.go
@@ -151,6 +151,9 @@ func testAccModelArmorTemplate_initial(context map[string]interface{}) string {
           custom_prompt_safety_error_message       = "This is a custom error message for prompt"
           custom_llm_response_safety_error_code    = 401
           enforcement_type                         = "INSPECT_ONLY"
+          filter_version_selector {
+            version = "LATEST"
+          }
         }
       }
     `, context)

--- a/website/docs/r/model_armor_template.html.markdown
+++ b/website/docs/r/model_armor_template.html.markdown
@@ -373,7 +373,7 @@ The following arguments are supported:
 
 * `filter_version_selector` -
   (Optional)
-  Selects the filter version to use for this template.
+  Selects the filter version to use for this template. Set exactly one of `alias` or `version`.
   Structure is [documented below](#nested_template_metadata_filter_version_selector).
 
 
@@ -385,10 +385,16 @@ The following arguments are supported:
 
 <a name="nested_template_metadata_filter_version_selector"></a>The `filter_version_selector` block supports:
 
+* `alias` -
+  (Optional)
+  A predefined filter version alias. The template automatically follows the
+  version this alias points to.
+  Possible values are: `FILTER_VERSION_ALIAS_STABLE`, `FILTER_VERSION_ALIAS_LATEST`.
+
 * `version` -
   (Optional)
-  The filter version. Accepts `LATEST` (newest version),
-  `STABLE` (current stable version), or a specific version such as `v1`.
+  Pins the template to a specific, immutable filter version. Expected
+  format is a case-sensitive string such as `v1` or `v2`.
 
 ## Attributes Reference
 

--- a/website/docs/r/model_armor_template.html.markdown
+++ b/website/docs/r/model_armor_template.html.markdown
@@ -371,12 +371,24 @@ The following arguments are supported:
   INSPECT_ONLY
   INSPECT_AND_BLOCK
 
+* `filter_version_selector` -
+  (Optional)
+  Selects the filter version to use for this template.
+  Structure is [documented below](#nested_template_metadata_filter_version_selector).
+
 
 <a name="nested_template_metadata_multi_language_detection"></a>The `multi_language_detection` block supports:
 
 * `enable_multi_language_detection` -
   (Required)
   If true, multi language detection will be enabled.
+
+<a name="nested_template_metadata_filter_version_selector"></a>The `filter_version_selector` block supports:
+
+* `version` -
+  (Optional)
+  The filter version. Accepts `LATEST` (newest version),
+  `STABLE` (current stable version), or a specific version such as `v1`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #27890

Exposes Model Armor filter version selection on `google_model_armor_template` via a new `filter_version_selector` block under `template_metadata`. Set either a version alias (`FILTER_VERSION_ALIAS_STABLE` / `FILTER_VERSION_ALIAS_LATEST`) or a pinned version (e.g. `v2`); omitting it keeps the API default (Stable).

```hcl
template_metadata {
  filter_version_selector {
    alias = "FILTER_VERSION_ALIAS_LATEST"
  }
}
```

The changes mirrors the API's `templateMetadata.filterVersionSelector` oneof ([guide](https://docs.cloud.google.com/model-armor/set-filter-version)) rather than the flat `filter_version` string suggested in the issue. This keeps `alias` and `version` as distinct, mutually exclusive fields as the API defines them, and passes values straight through — so `alias` takes the API's enum values (`FILTER_VERSION_ALIAS_LATEST`).
