### PR TITLE
update nightly job to Build Chain and chain sweepers

### DIFF
--- a/.teamcity/components/projects/global_sweepers_project.kt
+++ b/.teamcity/components/projects/global_sweepers_project.kt
@@ -32,11 +32,41 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used
     val serviceSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Project Sweeper", "GoogleProject", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
-    serviceSweeperConfig.addTrigger(NightlyTriggerConfiguration(startHour=12))
+    serviceSweeperConfig.dependencies {
+        snapshot(jetbrains.buildServer.configs.kotlin.AbsoluteId("GOOGLE_NIGHTLYTESTS_ALL_TESTS")) {
+            onDependencyFailure = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+            onDependencyCancel = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+        }
+        snapshot(jetbrains.buildServer.configs.kotlin.AbsoluteId("GOOGLE_BETA_NIGHTLYTESTS_ALL_TESTS")) {
+            onDependencyFailure = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+            onDependencyCancel = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+        }
+    }
+    serviceSweeperConfig.triggers {
+        finishBuildTrigger {
+            buildType = "GOOGLE_NIGHTLYTESTS_ALL_TESTS"
+            successfulOnly = false
+        }
+    }
 
     // Create build config for sweeping folder resources
     val folderSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Folder Sweeper", "GoogleFolder", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
-    folderSweeperConfig.addTrigger(NightlyTriggerConfiguration(startHour=12))
+    folderSweeperConfig.dependencies {
+        snapshot(jetbrains.buildServer.configs.kotlin.AbsoluteId("GOOGLE_NIGHTLYTESTS_ALL_TESTS")) {
+            onDependencyFailure = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+            onDependencyCancel = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+        }
+        snapshot(jetbrains.buildServer.configs.kotlin.AbsoluteId("GOOGLE_BETA_NIGHTLYTESTS_ALL_TESTS")) {
+            onDependencyFailure = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+            onDependencyCancel = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+        }
+    }
+    folderSweeperConfig.triggers {
+        finishBuildTrigger {
+            buildType = "GOOGLE_NIGHTLYTESTS_ALL_TESTS"
+            successfulOnly = false
+        }
+    }
 
     return Project{
         id(sweeperId)

--- a/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/.teamcity/components/projects/reused/nightly_tests.kt
@@ -38,11 +38,27 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     }
 
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
-    // and add cron trigger to them all
     val allPackages = getAllPackageInProviderVersion(providerName)
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
-    packageBuildConfigs.forEach { buildConfiguration ->
-        buildConfiguration.addTrigger(cron)
+
+    // Create a composite build that runs all package tests
+    val compositeConfig = jetbrains.buildServer.configs.kotlin.BuildType {
+        id(replaceCharsId("${projectId}_all_tests"))
+        name = "All Nightly Tests"
+        type = jetbrains.buildServer.configs.kotlin.BuildTypeSettings.Type.COMPOSITE
+
+        vcs {
+            root(vcsRoot)
+        }
+
+        dependencies {
+            packageBuildConfigs.forEach { bc ->
+                snapshot(bc) {
+                    onDependencyFailure = jetbrains.buildServer.configs.kotlin.FailureAction.ADD_PROBLEM
+                    onDependencyCancel = jetbrains.buildServer.configs.kotlin.FailureAction.ADD_PROBLEM
+                }
+            }
+        }
     }
 
     // Create build config for sweeping the nightly test project
@@ -54,9 +70,17 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         else -> throw Exception("Provider name not supplied when generating a nightly test subproject")
     }
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, sweepersList, projectId, vcsRoot, sharedResources, config)
-    val sweeperCron = cron.clone()
-    sweeperCron.startHour += 5  // Ensure triggered after the package test builds are triggered
-    serviceSweeperConfig.addTrigger(sweeperCron)
+    
+    // Add snapshot dependency on the composite config to run after tests finish
+    serviceSweeperConfig.dependencies {
+        snapshot(compositeConfig) {
+            onDependencyFailure = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+            onDependencyCancel = jetbrains.buildServer.configs.kotlin.FailureAction.IGNORE
+        }
+    }
+    
+    // Trigger the sweeper, which will recursively trigger the composite build and all package tests
+    serviceSweeperConfig.addTrigger(cron)
 
     return Project {
         id(projectId)
@@ -67,6 +91,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         packageBuildConfigs.forEach { buildConfiguration ->
             buildType(buildConfiguration)
         }
+        buildType(compositeConfig)
         buildType(serviceSweeperConfig)
 
         params{


### PR DESCRIPTION
Convert nightly CI jobs into a composite build and link the sweepers with dependency to provide an ordered execution and cleanup.