### PR TITLE
Fix recaptchaenterprise action settings map canonicalization

### DIFF
--- a/google/services/recaptchaenterprise/key_internal.go
+++ b/google/services/recaptchaenterprise/key_internal.go
@@ -925,6 +925,11 @@ func canonicalizeNewKeyWebSettingsChallengeSettingsActionSettingsMap(c *Client, 
 			items[k] = d
 		}
 	}
+	for k, n := range nw {
+		if _, ok := items[k]; !ok {
+			items[k] = n
+		}
+	}
 	return items
 }
 


### PR DESCRIPTION
Preserve live-only action-settings entries during canonicalization so updates that change action map keys are not skipped.

Fix for #28502 