### PR TITLE
set `permissions: write-all` for  issue-comment-created workflow

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -3,6 +3,7 @@ name: Remove "waiting-response" label on issue comment
 # user we label the issue waiting-response.
 # When a user comments on the issue the label is removed.
 
+permissions: write-all
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
Resolves failures we see in https://github.com/hashicorp/terraform-provider-google/actions/workflows/issue-comment-created.yml due to default org permissions being changed from `read | write` to just `read`