### PR TITLE
discoveryengine: remove ForceNew from json_schema in google_discovery_engine_schema

### DIFF
--- a/google/services/discoveryengine/resource_discovery_engine_schema.go
+++ b/google/services/discoveryengine/resource_discovery_engine_schema.go
@@ -108,6 +108,7 @@ func ResourceDiscoveryEngineSchema() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
@@ -166,7 +167,6 @@ only be one of "global", "us" and "eu".`,
 			"json_schema": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringIsJSON,
 				StateFunc:    func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s },
 				Description:  `The JSON representation of the schema.`,
@@ -396,7 +396,77 @@ func resourceDiscoveryEngineSchemaRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceDiscoveryEngineSchemaUpdate(d *schema.ResourceData, meta interface{}) error {
-	// Only the root field "deletion_policy", "labels", "terraform_labels", and virtual fields are mutable
+	clientSideFields := map[string]bool{"deletion_policy": true}
+	clientSideOnly := true
+	for field := range ResourceDiscoveryEngineSchema().Schema {
+		if d.HasChange(field) && !clientSideFields[field] {
+			clientSideOnly = false
+			break
+		}
+	}
+	if clientSideOnly {
+		log.Print("[DEBUG] Only client-side changes detected. Cancelling update operation.")
+		return resourceDiscoveryEngineSchemaRead(d, meta)
+	}
+
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for Schema: %s", err)
+	}
+	billingProject = project
+
+	obj := make(map[string]interface{})
+	jsonSchemaProp, err := expandDiscoveryEngineSchemaJsonSchema(d.Get("json_schema"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("json_schema"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, jsonSchemaProp)) {
+		obj["jsonSchema"] = jsonSchemaProp
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/collections/default_collection/dataStores/{{data_store_id}}/schemas/{{schema_id}}")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Updating Schema %q: %#v", d.Id(), obj)
+	headers := make(http.Header)
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating Schema %q: %s", d.Id(), err)
+	}
+
+	err = DiscoveryEngineOperationWaitTime(
+		config, res, project, "Updating Schema", userAgent,
+		d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return fmt.Errorf("Error waiting to update Schema: %s", err)
+	}
+
+	log.Printf("[DEBUG] Finished updating Schema %q: %#v", d.Id(), res)
+
 	return resourceDiscoveryEngineSchemaRead(d, meta)
 }
 

--- a/google/services/discoveryengine/resource_discovery_engine_schema_test.go
+++ b/google/services/discoveryengine/resource_discovery_engine_schema_test.go
@@ -1,0 +1,89 @@
+package discoveryengine_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/discoveryengine"
+)
+
+func TestAccDiscoveryEngineSchema_discoveryengineSchemaBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccTestPreCheck(t)
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDiscoveryEngineSchemaDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiscoveryEngineSchema_basic(context),
+			},
+			{
+				ResourceName:            "google_discovery_engine_schema.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_store_id", "location", "schema_id"},
+			},
+			{
+				Config: testAccDiscoveryEngineSchema_update(context),
+			},
+			{
+				ResourceName:            "google_discovery_engine_schema.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_store_id", "location", "schema_id"},
+			},
+		},
+	})
+}
+
+func testAccDiscoveryEngineSchema_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "basic" {
+  location                     = "global"
+  data_store_id                = "tf-test-schema-ds%{random_suffix}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = true
+}
+
+resource "google_discovery_engine_schema" "basic" {
+  location      = google_discovery_engine_data_store.basic.location
+  data_store_id = google_discovery_engine_data_store.basic.data_store_id
+  schema_id     = "tf-test-schema%{random_suffix}"
+  json_schema   = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\",\"datetime_detection\":true,\"geolocation_detection\":true}"
+}
+`, context)
+}
+
+func testAccDiscoveryEngineSchema_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "basic" {
+  location                     = "global"
+  data_store_id                = "tf-test-schema-ds%{random_suffix}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = true
+}
+
+resource "google_discovery_engine_schema" "basic" {
+  location      = google_discovery_engine_data_store.basic.location
+  data_store_id = google_discovery_engine_data_store.basic.data_store_id
+  schema_id     = "tf-test-schema%{random_suffix}"
+  json_schema   = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\",\"datetime_detection\":true,\"geolocation_detection\":true,\"properties\":{\"title\":{\"type\":\"string\",\"retrievable\":true,\"completable\":true}}}"
+}
+`, context)
+}


### PR DESCRIPTION
## Summary

- Removes `ForceNew: true` from the `json_schema` field on `google_discovery_engine_schema`, allowing in-place updates via the GCP `schemas.patch` API instead of forcing destroy+recreate
- Implements `resourceDiscoveryEngineSchemaUpdate` to send a `PATCH` request and wait on the resulting long-running operation
- Adds an `Update` timeout (60 min) to match the existing Create/Delete timeouts
- Adds an acceptance test covering the create-then-update flow

Fixes #28660

## Context

The GCP Discovery Engine API supports [in-place schema updates](https://cloud.google.com/generative-ai-app-builder/docs/update-schemas) for additive changes (new fields, annotation changes). The previous `ForceNew` behavior was problematic because the [`DeleteSchema` API](https://cloud.google.com/generative-ai-app-builder/docs/delete-schemas) refuses to delete a schema while documents exist in the data store, causing `terraform apply` to fail outright for any populated data store.

This follows the same pattern applied in #20603 for `google_discovery_engine_search_engine`.

## Test plan

- [ ] Acceptance test `TestAccDiscoveryEngineSchema_discoveryengineSchemaBasicExample_update` creates a schema, then updates it by adding a new field property, verifying in-place update without destroy+recreate
- [ ] Existing acceptance test `TestAccDiscoveryEngineSchema_discoveryengineSchemaBasicExample` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)