### PR TITLE
[7.46.0] Revert "[Filestore] Enable regional endpoint (REP) sup

### DIFF
--- a/google/services/filestore/filestore_operation.go
+++ b/google/services/filestore/filestore_operation.go
@@ -47,7 +47,6 @@ type FilestoreOperationWaiter struct {
 	Config    *transport_tpg.Config
 	UserAgent string
 	Project   string
-	Location  string
 	tpgresource.CommonOperationWaiter
 }
 
@@ -58,10 +57,6 @@ func (w *FilestoreOperationWaiter) QueryOp() (interface{}, error) {
 	// Returns the proper get.
 	url := transport_tpg.BaseUrl(Product, w.Config)
 	url += fmt.Sprintf("%s", w.CommonOperationWaiter.Op.Name)
-	if strings.Contains(url, "{{location}}") && w.Location == "" {
-		return nil, fmt.Errorf("failed to find location for a resource with a regionalized endpoint %s", url)
-	}
-	url = strings.ReplaceAll(url, "{{location}}", w.Location)
 	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:               w.Config,
 		Method:               "GET",
@@ -72,12 +67,11 @@ func (w *FilestoreOperationWaiter) QueryOp() (interface{}, error) {
 	})
 }
 
-func createFilestoreWaiter(config *transport_tpg.Config, op map[string]interface{}, project, location, activity, userAgent string) (*FilestoreOperationWaiter, error) {
+func createFilestoreWaiter(config *transport_tpg.Config, op map[string]interface{}, project, activity, userAgent string) (*FilestoreOperationWaiter, error) {
 	w := &FilestoreOperationWaiter{
 		Config:    config,
 		UserAgent: userAgent,
 		Project:   project,
-		Location:  location,
 	}
 	if err := w.CommonOperationWaiter.SetOp(op); err != nil {
 		return nil, err
@@ -86,8 +80,8 @@ func createFilestoreWaiter(config *transport_tpg.Config, op map[string]interface
 }
 
 // nolint: deadcode,unused
-func FilestoreOperationWaitTimeWithResponse(config *transport_tpg.Config, op map[string]interface{}, response *map[string]interface{}, project, location, activity, userAgent string, timeout time.Duration) error {
-	w, err := createFilestoreWaiter(config, op, project, location, activity, userAgent)
+func FilestoreOperationWaitTimeWithResponse(config *transport_tpg.Config, op map[string]interface{}, response *map[string]interface{}, project, activity, userAgent string, timeout time.Duration) error {
+	w, err := createFilestoreWaiter(config, op, project, activity, userAgent)
 	if err != nil {
 		return err
 	}
@@ -101,12 +95,12 @@ func FilestoreOperationWaitTimeWithResponse(config *transport_tpg.Config, op map
 	return json.Unmarshal(rawResponse, response)
 }
 
-func FilestoreOperationWaitTime(config *transport_tpg.Config, op map[string]interface{}, project, location, activity, userAgent string, timeout time.Duration) error {
+func FilestoreOperationWaitTime(config *transport_tpg.Config, op map[string]interface{}, project, activity, userAgent string, timeout time.Duration) error {
 	if val, ok := op["name"]; !ok || val == "" {
 		// This was a synchronous call - there is no operation to wait for.
 		return nil
 	}
-	w, err := createFilestoreWaiter(config, op, project, location, activity, userAgent)
+	w, err := createFilestoreWaiter(config, op, project, activity, userAgent)
 	if err != nil {
 		// If w is nil, the op was synchronous.
 		return err

--- a/google/services/filestore/product.go
+++ b/google/services/filestore/product.go
@@ -25,8 +25,6 @@ import (
 var Product = registry.Product{
 	Name:                 "filestore",
 	BaseUrl:              "https://file.googleapis.com/v1/",
-	RepUrl:               "https://file.{{location}}.rep.googleapis.com/v1/",
-	RepByDefault:         false,
 	CustomEndpointField:  "filestore_custom_endpoint",
 	CustomEndpointEnvVar: "GOOGLE_FILESTORE_CUSTOM_ENDPOINT",
 }

--- a/google/services/filestore/resource_filestore_backup.go
+++ b/google/services/filestore/resource_filestore_backup.go
@@ -318,9 +318,6 @@ func resourceFilestoreBackupCreate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	log.Printf("[DEBUG] Creating new Backup: %#v", obj)
 	billingProject := ""
@@ -359,10 +356,8 @@ func resourceFilestoreBackupCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	d.SetId(id)
 
-	// Derive location for use in REP endpoints
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Creating Backup", userAgent,
+		config, res, project, "Creating Backup", userAgent,
 		d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
@@ -407,9 +402,6 @@ func resourceFilestoreBackupRead(d *schema.ResourceData, meta interface{}) error
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/backups/{{name}}")
 	if err != nil {
 		return err
-	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
 	}
 
 	billingProject := ""
@@ -569,9 +561,6 @@ func resourceFilestoreBackupUpdate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	log.Printf("[DEBUG] Updating Backup %q: %#v", d.Id(), obj)
 	headers := make(http.Header)
@@ -620,10 +609,8 @@ func resourceFilestoreBackupUpdate(d *schema.ResourceData, meta interface{}) err
 			log.Printf("[DEBUG] Finished updating Backup %q: %#v", d.Id(), res)
 		}
 
-		// Derive location for use in REP endpoints
-		location := tpgresource.LocationFromId(d.Id())
 		err = FilestoreOperationWaitTime(
-			config, res, project, location, "Updating Backup", userAgent,
+			config, res, project, "Updating Backup", userAgent,
 			d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
@@ -666,9 +653,6 @@ func resourceFilestoreBackupDelete(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	var obj map[string]interface{}
 
@@ -695,10 +679,8 @@ func resourceFilestoreBackupDelete(d *schema.ResourceData, meta interface{}) err
 		return transport_tpg.HandleNotFoundError(err, d, "Backup")
 	}
 
-	// Derive location for use in REP endpoints
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Deleting Backup", userAgent,
+		config, res, project, "Deleting Backup", userAgent,
 		d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {

--- a/google/services/filestore/resource_filestore_backup_generated_test.go
+++ b/google/services/filestore/resource_filestore_backup_generated_test.go
@@ -138,9 +138,6 @@ func testAccCheckFilestoreBackupDestroyProducer(t *testing.T) func(s *terraform.
 			if err != nil {
 				return err
 			}
-			if strings.Contains(url, "{{location}}") {
-				return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-			}
 
 			billingProject := ""
 

--- a/google/services/filestore/resource_filestore_instance.go
+++ b/google/services/filestore/resource_filestore_instance.go
@@ -71,9 +71,8 @@ func ModifyFilestoreInstanceReplica(config *transport_tpg.Config, d *schema.Reso
 		return fmt.Errorf("Unable to %q google_filestore_instance %q: %s", method, d.Id(), err)
 	}
 
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Modifying Filestore Instance Replica", userAgent,
+		config, res, project, "Modifying Filestore Instance Replica", userAgent,
 		d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {
@@ -767,9 +766,6 @@ func resourceFilestoreInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	log.Printf("[DEBUG] Creating new Instance: %#v", obj)
 	billingProject := ""
@@ -825,10 +821,8 @@ func resourceFilestoreInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	d.SetId(id)
 
-	// Derive location for use in REP endpoints
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Creating Instance", userAgent,
+		config, res, project, "Creating Instance", userAgent,
 		d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
@@ -883,9 +877,6 @@ func resourceFilestoreInstanceRead(d *schema.ResourceData, meta interface{}) err
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/instances/{{name}}")
 	if err != nil {
 		return err
-	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
 	}
 
 	billingProject := ""
@@ -1067,9 +1058,6 @@ func resourceFilestoreInstanceUpdate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	log.Printf("[DEBUG] Updating Instance %q: %#v", d.Id(), obj)
 	headers := make(http.Header)
@@ -1134,10 +1122,8 @@ func resourceFilestoreInstanceUpdate(d *schema.ResourceData, meta interface{}) e
 			log.Printf("[DEBUG] Finished updating Instance %q: %#v", d.Id(), res)
 		}
 
-		// Derive location for use in REP endpoints
-		location := tpgresource.LocationFromId(d.Id())
 		err = FilestoreOperationWaitTime(
-			config, res, project, location, "Updating Instance", userAgent,
+			config, res, project, "Updating Instance", userAgent,
 			d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
@@ -1214,9 +1200,6 @@ func resourceFilestoreInstanceDelete(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	var obj map[string]interface{}
 
@@ -1243,10 +1226,8 @@ func resourceFilestoreInstanceDelete(d *schema.ResourceData, meta interface{}) e
 		return transport_tpg.HandleNotFoundError(err, d, "Instance")
 	}
 
-	// Derive location for use in REP endpoints
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Deleting Instance", userAgent,
+		config, res, project, "Deleting Instance", userAgent,
 		d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {

--- a/google/services/filestore/resource_filestore_instance_generated_test.go
+++ b/google/services/filestore/resource_filestore_instance_generated_test.go
@@ -248,9 +248,6 @@ func testAccCheckFilestoreInstanceDestroyProducer(t *testing.T) func(s *terrafor
 			if err != nil {
 				return err
 			}
-			if strings.Contains(url, "{{location}}") {
-				return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-			}
 
 			billingProject := ""
 

--- a/google/services/filestore/resource_filestore_snapshot.go
+++ b/google/services/filestore/resource_filestore_snapshot.go
@@ -269,9 +269,6 @@ func resourceFilestoreSnapshotCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	log.Printf("[DEBUG] Creating new Snapshot: %#v", obj)
 	billingProject := ""
@@ -310,10 +307,8 @@ func resourceFilestoreSnapshotCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	d.SetId(id)
 
-	// Derive location for use in REP endpoints
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Creating Snapshot", userAgent,
+		config, res, project, "Creating Snapshot", userAgent,
 		d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
@@ -363,9 +358,6 @@ func resourceFilestoreSnapshotRead(d *schema.ResourceData, meta interface{}) err
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/instances/{{instance}}/snapshots/{{name}}")
 	if err != nil {
 		return err
-	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
 	}
 
 	billingProject := ""
@@ -530,9 +522,6 @@ func resourceFilestoreSnapshotUpdate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	log.Printf("[DEBUG] Updating Snapshot %q: %#v", d.Id(), obj)
 	headers := make(http.Header)
@@ -577,10 +566,8 @@ func resourceFilestoreSnapshotUpdate(d *schema.ResourceData, meta interface{}) e
 			log.Printf("[DEBUG] Finished updating Snapshot %q: %#v", d.Id(), res)
 		}
 
-		// Derive location for use in REP endpoints
-		location := tpgresource.LocationFromId(d.Id())
 		err = FilestoreOperationWaitTime(
-			config, res, project, location, "Updating Snapshot", userAgent,
+			config, res, project, "Updating Snapshot", userAgent,
 			d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
@@ -623,9 +610,6 @@ func resourceFilestoreSnapshotDelete(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	if strings.Contains(url, "{{location}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-	}
 
 	var obj map[string]interface{}
 
@@ -652,10 +636,8 @@ func resourceFilestoreSnapshotDelete(d *schema.ResourceData, meta interface{}) e
 		return transport_tpg.HandleNotFoundError(err, d, "Snapshot")
 	}
 
-	// Derive location for use in REP endpoints
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Deleting Snapshot", userAgent,
+		config, res, project, "Deleting Snapshot", userAgent,
 		d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {

--- a/google/services/filestore/resource_filestore_snapshot_generated_test.go
+++ b/google/services/filestore/resource_filestore_snapshot_generated_test.go
@@ -197,9 +197,6 @@ func testAccCheckFilestoreSnapshotDestroyProducer(t *testing.T) func(s *terrafor
 			if err != nil {
 				return err
 			}
-			if strings.Contains(url, "{{location}}") {
-				return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-			}
 
 			billingProject := ""
 

--- a/website/docs/r/filestore_backup.html.markdown
+++ b/website/docs/r/filestore_backup.html.markdown
@@ -172,10 +172,6 @@ This resource provides the following
 - `update` - Default is 20 minutes.
 - `delete` - Default is 20 minutes.
 
-## Regional Endpoint Policies
-
-This resource supports Regional Endpoint Policies (REP). See the [provider reference](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#prefer_regional_endpoints) for more details on configuration.
-
 ## Import
 
 

--- a/website/docs/r/filestore_instance.html.markdown
+++ b/website/docs/r/filestore_instance.html.markdown
@@ -537,10 +537,6 @@ This resource provides the following
 - `update` - Default is 120 minutes.
 - `delete` - Default is 120 minutes.
 
-## Regional Endpoint Policies
-
-This resource supports Regional Endpoint Policies (REP). See the [provider reference](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#prefer_regional_endpoints) for more details on configuration.
-
 ## Import
 
 

--- a/website/docs/r/filestore_snapshot.html.markdown
+++ b/website/docs/r/filestore_snapshot.html.markdown
@@ -178,10 +178,6 @@ This resource provides the following
 - `update` - Default is 20 minutes.
 - `delete` - Default is 20 minutes.
 
-## Regional Endpoint Policies
-
-This resource supports Regional Endpoint Policies (REP). See the [provider reference](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#prefer_regional_endpoints) for more details on configuration.
-
 ## Import
 
 


### PR DESCRIPTION
Cherrypick of https://github.com/hashicorp/terraform-provider-google/commit/f6c64c94da0f94122e82be8fa87b9a206092edd9 into `release-7.46.0`.
Derived from https://github.com/GoogleCloudPlatform/magic-modules/pull/18742

```release-note:none

```