### PR TITLE
[8.0.0] Bump UA to dev8

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary
-	ProviderVersion = "dev7"
+	ProviderVersion = "dev8"
 )


### PR DESCRIPTION
Cherrypick of https://github.com/hashicorp/terraform-provider-google/commit/8df4e9a2f88391caea93c1d3d3cef4555f17ec1c into `release-8.0.0`.
Derived from https://github.com/GoogleCloudPlatform/magic-modules/pull/18780

```release-note:none

```