### PR TITLE
docs(pam): entitlement gcp_iam_access resource

### DIFF
--- a/website/docs/r/privileged_access_manager_entitlement.html.markdown
+++ b/website/docs/r/privileged_access_manager_entitlement.html.markdown
@@ -54,7 +54,7 @@ resource "google_privileged_access_manager_entitlement" "tfentitlement" {
                 role = "roles/storage.admin"
                 condition_expression = "request.time < timestamp(\"2024-04-23T18:30:00.000Z\")"
             }
-            resource = "//cloudresourcemanager.googleapis.com/projects/my-project-name"
+            resource = "//cloudresourcemanager.googleapis.com/projects/my-project-id"
             resource_type = "cloudresourcemanager.googleapis.com/Project"
         }
     }
@@ -167,7 +167,7 @@ The following arguments are supported:
 
 * `resource` -
   (Required)
-  Name of the resource.
+  The ID of the resource.
 
 * `role_bindings` -
   (Required)


### PR DESCRIPTION
Google API expects project ID instead of name

Google API rejects the name in resource value when using the doc example. It results the following error:  `Error: Error creating Entitlement: googleapi: Error 403: Permission "resourcemanager.projects.setIamPolicy" denied on "//cloudresourcemanager.googleapis.com/projects/xxxxxx"

This PR is to reflect the API needs for a better user experience.

[Reference](https://docs.cloud.google.com/iam/docs/pam-create-entitlements#iam-pam-create-entitlements-rest:~:text=The%20organization%2C%20folder%2C%20or%20project%20to%20create%20the%20entitlement%20in%2C%20in%20the%20format%20of%20organizations/ORGANIZATION_ID%2C%20folders/FOLDER_ID%2C%20or%20projects/PROJECT_ID.%20Project%20IDs%20are%20alphanumeric%20strings%2C%20like%20my%2Dproject.%20Folder%20and%20organization%20IDs%20are%20numeric%2C%20like%20123456789012.)

