### PR TITLE
fix(pubsub): allow importing subscriptions and resolving through full paths

### DIFF
--- a/google/services/pubsub/iam_pubsub_subscription.go
+++ b/google/services/pubsub/iam_pubsub_subscription.go
@@ -46,30 +46,80 @@ var IamPubsubSubscriptionSchema = map[string]*schema.Schema{
 }
 
 type PubsubSubscriptionIamUpdater struct {
+	project      string
 	subscription string
 	d            tpgresource.TerraformResourceData
 	Config       *transport_tpg.Config
 }
 
 func NewPubsubSubscriptionIamUpdater(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (tpgiamresource.ResourceIamUpdater, error) {
-	project, err := tpgresource.GetProject(d, config)
+	values := make(map[string]string)
+
+	project, _ := tpgresource.GetProject(d, config)
+	if project != "" {
+		if err := d.Set("project", project); err != nil {
+			return nil, fmt.Errorf("Error setting project: %s", err)
+		}
+	}
+	values["project"] = project
+	if v, ok := d.GetOk("subscription"); ok {
+		values["subscription"] = v.(string)
+	}
+
+	// We may have gotten either a long or short name, so attempt to parse long name if possible
+	m, err := tpgresource.GetImportIdQualifiers([]string{"projects/(?P<project>[^/]+)/subscriptions/(?P<subscription>[^/]+)", "(?P<project>[^/]+)/(?P<subscription>[^/]+)", "(?P<subscription>[^/]+)"}, d, config, d.Get("subscription").(string))
 	if err != nil {
 		return nil, err
 	}
 
-	subscription := GetComputedSubscriptionName(project, d.Get("subscription").(string))
+	for k, v := range m {
+		values[k] = v
+	}
 
-	return &PubsubSubscriptionIamUpdater{
-		subscription: subscription,
+	u := &PubsubSubscriptionIamUpdater{
+		project:      values["project"],
+		subscription: values["subscription"],
 		d:            d,
 		Config:       config,
-	}, nil
+	}
+
+	if err := d.Set("project", u.project); err != nil {
+		return nil, fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("subscription", u.GetResourceId()); err != nil {
+		return nil, fmt.Errorf("Error setting subscription: %s", err)
+	}
+
+	return u, nil
 }
 
-func PubsubSubscriptionIdParseFunc(d *schema.ResourceData, _ *transport_tpg.Config) error {
-	if err := d.Set("subscription", d.Id()); err != nil {
+func PubsubSubscriptionIdParseFunc(d *schema.ResourceData, config *transport_tpg.Config) error {
+	values := make(map[string]string)
+
+	project, _ := tpgresource.GetProject(d, config)
+	if project != "" {
+		values["project"] = project
+	}
+
+	m, err := tpgresource.GetImportIdQualifiers([]string{"projects/(?P<project>[^/]+)/subscriptions/(?P<subscription>[^/]+)", "(?P<project>[^/]+)/(?P<subscription>[^/]+)", "(?P<subscription>[^/]+)"}, d, config, d.Id())
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		values[k] = v
+	}
+
+	u := &PubsubSubscriptionIamUpdater{
+		project:      values["project"],
+		subscription: values["subscription"],
+		d:            d,
+		Config:       config,
+	}
+	if err := d.Set("subscription", u.GetResourceId()); err != nil {
 		return fmt.Errorf("Error setting subscription: %s", err)
 	}
+	d.SetId(u.GetResourceId())
 	return nil
 }
 
@@ -79,7 +129,7 @@ func (u *PubsubSubscriptionIamUpdater) GetResourceIamPolicy() (*cloudresourceman
 		return nil, err
 	}
 
-	p, err := NewClient(u.Config, userAgent).Projects.Subscriptions.GetIamPolicy(u.subscription).Do()
+	p, err := NewClient(u.Config, userAgent).Projects.Subscriptions.GetIamPolicy(u.GetResourceId()).Do()
 
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
@@ -104,7 +154,7 @@ func (u *PubsubSubscriptionIamUpdater) SetResourceIamPolicy(policy *cloudresourc
 		return err
 	}
 
-	_, err = NewClient(u.Config, userAgent).Projects.Subscriptions.SetIamPolicy(u.subscription, &pubsub.SetIamPolicyRequest{
+	_, err = NewClient(u.Config, userAgent).Projects.Subscriptions.SetIamPolicy(u.GetResourceId(), &pubsub.SetIamPolicyRequest{
 		Policy: pubsubPolicy,
 	}).Do()
 
@@ -116,15 +166,15 @@ func (u *PubsubSubscriptionIamUpdater) SetResourceIamPolicy(policy *cloudresourc
 }
 
 func (u *PubsubSubscriptionIamUpdater) GetResourceId() string {
-	return u.subscription
+	return fmt.Sprintf("projects/%s/subscriptions/%s", u.project, u.subscription)
 }
 
 func (u *PubsubSubscriptionIamUpdater) GetMutexKey() string {
-	return fmt.Sprintf("iam-pubsub-subscription-%s", u.subscription)
+	return fmt.Sprintf("iam-pubsub-subscription-%s", u.GetResourceId())
 }
 
 func (u *PubsubSubscriptionIamUpdater) DescribeResource() string {
-	return fmt.Sprintf("pubsub subscription %q", u.subscription)
+	return fmt.Sprintf("pubsub subscription %q", u.GetResourceId())
 }
 
 // v1 and v2 policy are identical

--- a/google/services/pubsub/iam_pubsub_subscription_test.go
+++ b/google/services/pubsub/iam_pubsub_subscription_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/pubsub"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccPubsubSubscriptionIamBinding(t *testing.T) {
@@ -271,4 +273,139 @@ data "google_pubsub_subscription_iam_policy" "foo" {
   subscription = google_pubsub_subscription.subscription.id
 }
 `, topic, subscription, account, role)
+}
+
+func TestPubsubSubscriptionIdParseFunc(t *testing.T) {
+	cases := map[string]struct {
+		importId     string
+		config       *transport_tpg.Config
+		expectedSub  string
+		expectedId   string
+		expectError  bool
+	}{
+		"full subscription path": {
+			importId:    "projects/my-project/subscriptions/my-subscription",
+			expectedSub: "projects/my-project/subscriptions/my-subscription",
+			expectedId:  "projects/my-project/subscriptions/my-subscription",
+		},
+		"full subscription path with special chars": {
+			importId:    "projects/test-project-123.domain/subscriptions/sub-abc_123.test",
+			expectedSub: "projects/test-project-123.domain/subscriptions/sub-abc_123.test",
+			expectedId:  "projects/test-project-123.domain/subscriptions/sub-abc_123.test",
+		},
+		"project slash subscription format": {
+			importId:    "my-project/my-subscription",
+			expectedSub: "projects/my-project/subscriptions/my-subscription",
+			expectedId:  "projects/my-project/subscriptions/my-subscription",
+		},
+		"short subscription name with default project": {
+			importId:    "my-subscription",
+			config:      &transport_tpg.Config{Project: "default-project"},
+			expectedSub: "projects/default-project/subscriptions/my-subscription",
+			expectedId:  "projects/default-project/subscriptions/my-subscription",
+		},
+		"short subscription name without project returns error": {
+			importId:    "my-subscription",
+			config:      nil,
+			expectError: true,
+		},
+		"invalid path with topics": {
+			importId:    "projects/my-project/topics/my-subscription",
+			expectError: true,
+		},
+		"incomplete path": {
+			importId:    "projects/my-project/subscriptions",
+			expectError: true,
+		},
+		"extra path segments": {
+			importId:    "projects/my-project/subscriptions/my-subscription/extra",
+			expectError: true,
+		},
+		"empty import id": {
+			importId:    "",
+			expectError: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, pubsub.IamPubsubSubscriptionSchema, map[string]interface{}{})
+			d.SetId(tc.importId)
+
+			err := pubsub.PubsubSubscriptionIdParseFunc(d, tc.config)
+			if (err != nil) != tc.expectError {
+				t.Fatalf("expected error: %v, got: %v", tc.expectError, err)
+			}
+
+			if !tc.expectError {
+				if v := d.Get("subscription").(string); v != tc.expectedSub {
+					t.Errorf("expected subscription %q, got %q", tc.expectedSub, v)
+				}
+				if d.Id() != tc.expectedId {
+					t.Errorf("expected id %q, got %q", tc.expectedId, d.Id())
+				}
+			}
+		})
+	}
+}
+
+func TestNewPubsubSubscriptionIamUpdater(t *testing.T) {
+	cases := map[string]struct {
+		schemaMap          map[string]interface{}
+		config             *transport_tpg.Config
+		expectedProject    string
+		expectedSub        string
+		expectedResourceId string
+		expectError        bool
+	}{
+		"imported full subscription path": {
+			schemaMap: map[string]interface{}{
+				"subscription": "projects/my-project/subscriptions/my-subscription",
+			},
+			expectedProject:    "my-project",
+			expectedSub:        "projects/my-project/subscriptions/my-subscription",
+			expectedResourceId: "projects/my-project/subscriptions/my-subscription",
+		},
+		"short subscription with project field set": {
+			schemaMap: map[string]interface{}{
+				"project":      "my-project",
+				"subscription": "my-subscription",
+			},
+			expectedProject:    "my-project",
+			expectedSub:        "projects/my-project/subscriptions/my-subscription",
+			expectedResourceId: "projects/my-project/subscriptions/my-subscription",
+		},
+		"short subscription with provider config project": {
+			schemaMap: map[string]interface{}{
+				"subscription": "my-subscription",
+			},
+			config:             &transport_tpg.Config{Project: "default-project"},
+			expectedProject:    "default-project",
+			expectedSub:        "projects/default-project/subscriptions/my-subscription",
+			expectedResourceId: "projects/default-project/subscriptions/my-subscription",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, pubsub.IamPubsubSubscriptionSchema, tc.schemaMap)
+
+			updater, err := pubsub.NewPubsubSubscriptionIamUpdater(d, tc.config)
+			if (err != nil) != tc.expectError {
+				t.Fatalf("expected error: %v, got: %v", tc.expectError, err)
+			}
+
+			if !tc.expectError {
+				if v := d.Get("project").(string); v != tc.expectedProject {
+					t.Errorf("expected project %q, got %q", tc.expectedProject, v)
+				}
+				if v := d.Get("subscription").(string); v != tc.expectedSub {
+					t.Errorf("expected subscription %q, got %q", tc.expectedSub, v)
+				}
+				if updater.GetResourceId() != tc.expectedResourceId {
+					t.Errorf("expected resourceId %q, got %q", tc.expectedResourceId, updater.GetResourceId())
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17684 by emulating topic parsing functionality, e.g [PubsubTopicIdParseFunc](https://github.com/hashicorp/terraform-provider-google/blob/22f2de39557d978f070af41629675643b154e396/google/services/pubsub/iam_pubsub_topic.go#L151-L179). This allows users to specify either an unqualified topic and project separately, or the two as a singular path.